### PR TITLE
Add npm package binary discovery and fix Ultraplan for v2.1.119

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -126,14 +126,63 @@ catch {
 New-Item -ItemType Directory -Force -Path $ClawDir | Out-Null
 New-Item -ItemType Directory -Force -Path $BinDir  | Out-Null
 
+# Helper: Write UTF-8 without BOM (PowerShell 5.1 Set-Content adds BOM by default)
+function Write-TextFile($Path, $Content) {
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
 $NativeBin = $null
+
+# 1. Try npm package installation
+# npm package structure:
+#   - Main package: @anthropic-ai/claude-code (has bin/claude.exe placeholder, replaced by postinstall)
+#   - Platform packages: @anthropic-ai/claude-code-win32-{x64,arm64} (binary in root as claude.exe)
+# After postinstall, the native binary is at: @anthropic-ai/claude-code/bin/claude.exe
+if (-not $NativeBin) {
+    $npmRoot = $null
+    try { $npmRoot = npm root -g 2>$null } catch {}
+    # Check global installation (postinstall already ran)
+    if ($npmRoot -and (Test-Path (Join-Path $npmRoot "@anthropic-ai\claude-code\bin\claude.exe"))) {
+        $candidate = Join-Path $npmRoot "@anthropic-ai\claude-code\bin\claude.exe"
+        if ((Get-Item $candidate).Length -gt 10MB) {
+            $NativeBin = $candidate
+        }
+    }
+    # Check local node_modules if in a project
+    if (-not $NativeBin -and (Test-Path "package.json") -and (Test-Path "node_modules\@anthropic-ai\claude-code\bin\claude.exe")) {
+        $candidate = "node_modules\@anthropic-ai\claude-code\bin\claude.exe"
+        if ((Get-Item $candidate).Length -gt 10MB) {
+            $NativeBin = $candidate
+        }
+    }
+    # Fallback: check platform-specific package directly (if postinstall didn't run)
+    if (-not $NativeBin -and $npmRoot) {
+        $arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "arm64" }
+        $platformPkg = Join-Path $npmRoot "@anthropic-ai\claude-code-win32-$arch"
+        if (-not (Test-Path $platformPkg)) {
+            # Try local node_modules
+            if (Test-Path "package.json") {
+                $platformPkg = "node_modules\@anthropic-ai\claude-code-win32-$arch"
+            }
+        }
+        if ((Test-Path $platformPkg) -and (Test-Path (Join-Path $platformPkg "claude.exe"))) {
+            $candidate = Join-Path $platformPkg "claude.exe"
+            if ((Get-Item $candidate).Length -gt 10MB) {
+                $NativeBin = $candidate
+            }
+        }
+    }
+}
+
+# 2. Check official installer locations
 $searchPaths = @(
     (Join-Path $env:USERPROFILE ".local\share\claude\versions"),
     (Join-Path $env:LOCALAPPDATA "Programs\claude-code")
 )
 
 foreach ($dir in $searchPaths) {
-    if (Test-Path $dir -PathType Container) {
+    if (-not $NativeBin -and (Test-Path $dir -PathType Container)) {
         $candidates = Get-ChildItem $dir -File -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -like "*.exe" -or $_.Extension -eq "" } |
             Where-Object { $_.Length -gt 10MB } |
@@ -145,7 +194,7 @@ foreach ($dir in $searchPaths) {
     }
 }
 
-# Also check backed-up claude.orig.exe
+# 3. Also check backed-up claude.orig.exe
 if (-not $NativeBin) {
     $origExe = Join-Path $BinDir "claude.orig.exe"
     if ((Test-Path $origExe) -and (Get-Item $origExe).Length -gt 10MB) {
@@ -163,7 +212,7 @@ if (-not $NativeBin) {
 
 # Always write the extractor (used for cli.js and/or .node modules)
 $extractorPath = Join-Path $ClawDir "extract-natives.mjs"
-@'
+$extractorContent = @'
 #!/usr/bin/env node
 /**
  * ClawGod native module extractor
@@ -567,7 +616,9 @@ function main() {
 }
 
 main();
-'@ | Set-Content $extractorPath -Encoding UTF8
+'@
+# Use UTF-8 without BOM for the extractor script
+Write-TextFile $extractorPath $extractorContent
 
 # ─── Extract cli.js + native modules from Bun binary ──────────
 
@@ -593,7 +644,7 @@ Write-Dim "Extracting native modules from $(Split-Path $NativeBin -Leaf) ..."
 
 Write-Dim "Rewriting bunfs paths and IIFE invocation ..."
 $postProc = Join-Path $ClawDir "post-process.mjs"
-@'
+$postProcContent = @'
 import { readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -620,7 +671,8 @@ code = code.replace(/\}\)\s*$/, '})(exports, require, module, __filename, __dirn
 writeFileSync(dst, code);
 unlinkSync(src);
 console.log(`cli.original.cjs: ${code.length} bytes`);
-'@ | Set-Content $postProc -Encoding UTF8
+'@
+Write-TextFile $postProc $postProcContent
 & node $postProc 2>&1 | ForEach-Object { Write-Host "  $_" }
 if (-not (Test-Path (Join-Path $ClawDir "cli.original.cjs"))) {
     Write-Err "Post-process failed"
@@ -633,7 +685,7 @@ Write-OK "cli.original.cjs ready ($(Split-Path $NativeBin -Leaf))"
 
 # ─── Write re-patch helper (used by wrapper on version drift) ─────────
 
-@'
+$repatchContent = @'
 #!/usr/bin/env bun
 import { spawnSync } from 'child_process';
 import { writeFileSync, existsSync, mkdirSync, rmSync } from 'fs';
@@ -673,12 +725,13 @@ run('patcher', [patcher]);
 
 writeFileSync(join(here, '.source-version'), basename(nativeBin) + '\n');
 console.log(`[clawgod] re-patched to ${basename(nativeBin)}`);
-'@ | Set-Content (Join-Path $ClawDir "repatch.mjs") -Encoding UTF8
+'@
+Write-TextFile (Join-Path $ClawDir "repatch.mjs") $repatchContent
 Write-OK "Re-patch helper installed (repatch.mjs)"
 
 # ─── Write wrapper (cli.cjs, runs under Bun) ──────────────────
 
-@'
+$cliContent = @'
 #!/usr/bin/env bun
 const { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, statSync } = require('fs');
 const { join, basename } = require('path');
@@ -777,7 +830,8 @@ if (!process.env.CLAUDE_INTERNAL_FC_OVERRIDES && existsSync(featuresFile)) {
 }
 
 require('./cli.original.cjs');
-'@ | Set-Content (Join-Path $ClawDir "cli.cjs") -Encoding UTF8
+'@
+Write-TextFile (Join-Path $ClawDir "cli.cjs") $cliContent
 Write-OK "Wrapper created (cli.cjs)"
 
 # ─── Write universal patcher ──────────────────────────
@@ -842,6 +896,15 @@ const patches = [
   },
   {
     name: 'Ultraplan enable',
+    // v2.1.119+: isEnabled:()=>da() where da() is a minified function
+    pattern: /(argumentHint:"<prompt>",isEnabled:\(\)=>)da\(\)/g,
+    replacer: (m, prefix) => `${prefix}!0`,
+    sentinel: 'argumentHint:"<prompt>",isEnabled:()=>da()',
+    optional: true,
+  },
+  {
+    // Legacy (<=v2.1.118): isEnabled:()=>!1
+    name: 'Ultraplan enable (legacy)',
     pattern: /(name:"ultraplan",description:`[^`]+`,argumentHint:"<prompt>",isEnabled:\(\)=>)!1/g,
     replacer: (m, prefix) => `${prefix}!0`,
     optional: true,
@@ -1021,7 +1084,7 @@ if (!dryRun && !verify && applied > 0) {
 console.log(`${'='.repeat(55)}\n`);
 '@
 
-Set-Content (Join-Path $ClawDir "patch.mjs") $patcherCode -Encoding UTF8
+Write-TextFile (Join-Path $ClawDir "patch.mjs") $patcherCode
 Write-OK "Patcher created (patch.mjs)"
 
 # ─── Apply patches ────────────────────────────────────
@@ -1033,7 +1096,7 @@ node (Join-Path $ClawDir "patch.mjs")
 
 $featuresFile = Join-Path $ClawDir "features.json"
 if (-not (Test-Path $featuresFile)) {
-    @'
+    $featuresContent = @'
 {
   "tengu_harbor": true,
   "tengu_session_memory": true,
@@ -1044,7 +1107,8 @@ if (-not (Test-Path $featuresFile)) {
   "tengu_desktop_upsell": false,
   "tengu_prompt_cache_1h_config": {"allowlist": ["*"]}
 }
-'@ | Set-Content $featuresFile -Encoding UTF8
+'@
+    Write-TextFile $featuresFile $featuresContent
     Write-OK "Default features.json created"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -131,8 +131,51 @@ info "ripgrep: $(rg --version | head -1)"
 mkdir -p "$CLAWGOD_DIR" "$BIN_DIR"
 
 NATIVE_BIN=""
+
+# 1. Try npm package installation (check platform-specific optional package first)
+# npm package structure:
+#   - Main package: @anthropic-ai/claude-code (has bin/claude.exe placeholder, replaced by postinstall)
+#   - Platform packages: @anthropic-ai/claude-code-{platform}-{arch} (binary in root, named 'claude' or 'claude.exe')
+# After postinstall, the native binary is at: @anthropic-ai/claude-code/bin/claude[.exe]
+if command -v npm &>/dev/null; then
+  NPM_ROOT=$(npm root -g 2>/dev/null) || NPM_ROOT=""
+  # Check global installation (postinstall already ran)
+  if [ -n "$NPM_ROOT" ] && [ -d "$NPM_ROOT/@anthropic-ai/claude-code" ]; then
+    candidate="$NPM_ROOT/@anthropic-ai/claude-code/bin/claude"
+    if [ -f "$candidate" ] && file "$candidate" 2>/dev/null | grep -qE "Mach-O|ELF"; then
+      NATIVE_BIN="$candidate"
+    fi
+  fi
+  # Check local node_modules if in a project
+  if [ -z "$NATIVE_BIN" ] && [ -f "package.json" ] && [ -d "node_modules/@anthropic-ai/claude-code" ]; then
+    candidate="node_modules/@anthropic-ai/claude-code/bin/claude"
+    if [ -f "$candidate" ] && file "$candidate" 2>/dev/null | grep -qE "Mach-O|ELF"; then
+      NATIVE_BIN="$candidate"
+    fi
+  fi
+  # Fallback: check platform-specific package directly (if postinstall didn't run)
+  if [ -z "$NATIVE_BIN" ]; then
+    platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+    # Map arch names (x86_64 -> x64, aarch64 -> arm64)
+    arch_normalized=$(echo "$arch" | sed 's/x86_64/x64/;s/aarch64/arm64/')
+    platform_pkg="$NPM_ROOT/@anthropic-ai/claude-code-$platform-$arch_normalized"
+    if [ -z "$platform_pkg" ] || [ ! -d "$platform_pkg" ]; then
+      # Try local node_modules
+      [ -f "package.json" ] && platform_pkg="node_modules/@anthropic-ai/claude-code-$platform-$arch_normalized"
+    fi
+    if [ -d "$platform_pkg" ]; then
+      candidate="$platform_pkg/claude"
+      if [ -f "$candidate" ] && file "$candidate" 2>/dev/null | grep -qE "Mach-O|ELF"; then
+        NATIVE_BIN="$candidate"
+      fi
+    fi
+  fi
+fi
+
+# 2. Try official installer location (~/.local/share/claude/versions)
 VERSIONS_DIR="$HOME/.local/share/claude/versions"
-if [ -d "$VERSIONS_DIR" ]; then
+if [ -z "$NATIVE_BIN" ] && [ -d "$VERSIONS_DIR" ]; then
   for f in $(ls -t "$VERSIONS_DIR"/* 2>/dev/null); do
     if file "$f" 2>/dev/null | grep -qE "Mach-O|ELF"; then
       NATIVE_BIN="$f"
@@ -141,7 +184,7 @@ if [ -d "$VERSIONS_DIR" ]; then
   done
 fi
 
-# Fallback: backed-up .orig from a prior clawgod install
+# 3. Fallback: backed-up .orig from a prior clawgod install
 if [ -z "$NATIVE_BIN" ] && [ -e "$BIN_DIR/claude.orig" ]; then
   if file "$BIN_DIR/claude.orig" 2>/dev/null | grep -qE "Mach-O|ELF"; then
     NATIVE_BIN="$BIN_DIR/claude.orig"
@@ -856,9 +899,18 @@ const patches = [
   },
   {
     name: 'Ultraplan enable',
+    // v2.1.119+: isEnabled:()=>da() where da() is a minified function
+    pattern: /(argumentHint:"<prompt>",isEnabled:\(\)=>)da\(\)/g,
+    replacer: (m, prefix) => `${prefix}!0`,
+    sentinel: 'argumentHint:"<prompt>",isEnabled:()=>da()',
+    optional: true,
+  },
+  {
+    // Legacy (≤v2.1.118): isEnabled:()=>!1
+    name: 'Ultraplan enable (legacy)',
     pattern: /(name:"ultraplan",description:`[^`]+`,argumentHint:"<prompt>",isEnabled:\(\)=>)!1/g,
     replacer: (m, prefix) => `${prefix}!0`,
-    optional: true,  // v2.1.89+ merged into /plan, no standalone command
+    optional: true,
   },
   {
     // ≤v2.1.110: function X(){return Y("tengu_review_bughunter_config",null)?.enabled===!0}


### PR DESCRIPTION
## Summary
- Add npm package binary discovery for both install.sh and install.ps1
- Fix Ultraplan patcher for v2.1.119+ (uses `isEnabled:()=>da()` instead of `!1`)
- Add Write-TextFile helper in install.ps1 to avoid UTF-8 BOM issues on Windows

## Details

### npm Package Binary Discovery
The `@anthropic-ai/claude-code` npm package structure:
- Main package has a placeholder `bin/claude.exe` that gets replaced by postinstall
- Platform-specific packages (`@anthropic-ai/claude-code-{platform}-{arch}`) contain the actual binary

The installers now:
1. Check `@anthropic-ai/claude-code/bin/claude[.exe]` (after postinstall ran)
2. Fallback to platform-specific package directly (if postinstall didn't run)

### Ultraplan v2.1.119 Fix
In v2.1.119, the Ultraplan feature flag changed from:
```javascript
isEnabled:()=>!1  // v2.1.118 and earlier
```
to:
```javascript
isEnabled:()=>da()  // v2.1.119+, where da() is a minified function
```

The patcher now handles both patterns.

### UTF-8 BOM Fix (Windows)
PowerShell 5.1's `Set-Content -Encoding UTF8` adds a BOM by default, which can cause issues with Node.js scripts. Added `Write-TextFile` helper that writes UTF-8 without BOM.

## Test Plan
- [ ] Verify npm package binary discovery works on fresh npm install
- [ ] Verify Ultraplan patcher works with v2.1.119 binary
- [ ] Verify no BOM issues in generated scripts on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)