### PR TITLE
fix(installer): resolve garbled characters in .cmd launcher for non-ASCII Windows usernames

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1281,9 +1281,20 @@ Write-OK "Bun loads cli.original.cjs"
 
 # ─── Replace claude command ───────────────────────────
 
-$cliPath = (Join-Path $ClawDir "cli.cjs") -replace '\\', '\\'
-$bunPath = $BunBin -replace '\\', '\\'
-$launcherContent = "@echo off`r`n`"$bunPath`" `"$cliPath`" %*"
+# Build launcher content using %USERPROFILE% env var where possible to avoid
+# encoding issues when the profile path contains non-ASCII characters (e.g.
+# Chinese/Korean/Japanese usernames). cmd.exe resolves %USERPROFILE% at
+# runtime so no problematic characters need to be baked into the .cmd file.
+$cliPathInCmd = "%USERPROFILE%\.clawgod\cli.cjs"
+if ($BunBin.StartsWith($env:USERPROFILE, [StringComparison]::OrdinalIgnoreCase)) {
+    $bunRelative = $BunBin.Substring($env:USERPROFILE.Length).TrimStart('\', '/')
+    $bunPathInCmd = "%USERPROFILE%\$bunRelative"
+} else {
+    # Bun outside USERPROFILE (e.g. system-wide install) — absolute path,
+    # which is fine because system paths don't contain non-ASCII characters.
+    $bunPathInCmd = $BunBin
+}
+$launcherContent = "@echo off`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
 
 # Find and back up original claude
 $claudeCmd = Join-Path $BinDir "claude.cmd"
@@ -1357,7 +1368,7 @@ if (Test-Path $claudeExe) {
 #  - User can invoke patched explicitly via `clawgod` regardless of which
 #    binary 'claude' resolves to
 foreach ($cmd in @("claude", "clawgod")) {
-    $launcherContent | Set-Content (Join-Path $BinDir "$cmd.cmd") -Encoding ASCII
+    $launcherContent | Set-Content (Join-Path $BinDir "$cmd.cmd") -Encoding Default
 }
 Write-OK "Commands 'claude' + 'clawgod' → patched"
 

--- a/install.ps1
+++ b/install.ps1
@@ -1286,12 +1286,16 @@ Write-OK "Bun loads cli.original.cjs"
 # Chinese/Korean/Japanese usernames). cmd.exe resolves %USERPROFILE% at
 # runtime so no problematic characters need to be baked into the .cmd file.
 $cliPathInCmd = "%USERPROFILE%\.clawgod\cli.cjs"
-if ($BunBin.StartsWith($env:USERPROFILE, [StringComparison]::OrdinalIgnoreCase)) {
-    $bunRelative = $BunBin.Substring($env:USERPROFILE.Length).TrimStart('\', '/')
+$normalizedUserProfile = $env:USERPROFILE.TrimEnd('\', '/')
+$normalizedBunBin = $BunBin.TrimEnd('\', '/')
+$userProfilePrefix = "$normalizedUserProfile\"
+if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::OrdinalIgnoreCase) -or
+    $normalizedBunBin.StartsWith($userProfilePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    $bunRelative = $normalizedBunBin.Substring($normalizedUserProfile.Length).TrimStart('\', '/')
     $bunPathInCmd = "%USERPROFILE%\$bunRelative"
 } else {
-    # Bun outside USERPROFILE (e.g. system-wide install) — absolute path,
-    # which is fine because system paths don't contain non-ASCII characters.
+    # Bun outside USERPROFILE (e.g. system-wide install) — fall back to
+    # absolute path since %USERPROFILE%-relative expansion doesn't apply.
     $bunPathInCmd = $BunBin
 }
 $launcherContent = "@echo off`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"


### PR DESCRIPTION
## Summary

Fix: Windows installer .cmd launcher garbled with ??? for non-ASCII usernames (Chinese/Japanese/Korean).

### Root Cause

`install.ps1` embedded resolved absolute paths (e.g. `C:\Users\<CJK>\...`) into the .cmd launcher, then wrote them with `-Encoding ASCII`. ASCII cannot represent CJK characters, so they all became `???`, and Bun could not find `cli.cjs`.

### Fix

1. **Use `%USERPROFILE%` env var instead of resolved paths** — `cmd.exe` expands it at runtime, so the .cmd file stays pure ASCII.
2. **`-Encoding ASCII` → `-Encoding Default`** — defense-in-depth for the edge case where Bun lives outside USERPROFILE.
3. **Path separator boundary on `StartsWith`** — prevents `C:\Users\ab` from falsely matching `C:\Users\abc\...`.

### Generated .cmd

```batch
@echo off
"%USERPROFILE%\.bun\bin\bun.exe" "%USERPROFILE%\.clawgod\cli.cjs" %*
```

## Test Plan

- [ ] Run `install.ps1` on Windows with CJK username, verify `claude.cmd` / `clawgod.cmd` are clean
- [ ] `claude` and `clawgod` commands launch correctly
- [ ] Bun outside USERPROFILE (system-wide install) still works