### PR TITLE
fix(windows): resolve bun.ps1 to bun.exe in launcher generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install these **before** running the ClawGod installer:
 | **Claude Code** (native binary) | ClawGod patches the official Bun standalone binary you already have | [`claude.ai/install.sh`](https://claude.ai/install.sh) (macOS/Linux) or [`claude.ai/install.ps1`](https://claude.ai/install.ps1) (Windows) |
 | **ripgrep** | Required by Claude Code's Grep tool | `brew install ripgrep` / `apt install ripgrep` / `winget install BurntSushi.ripgrep.MSVC` |
 | **Node.js >= 18** | Used by the patcher | [nodejs.org](https://nodejs.org) |
-| **Bun** | Runtime for the patched cli.js; auto-installed if missing [bun.sh](https://bun.sh) | Upgrade: `bun upgrade --canary` or `powershell -c "iex & {$(irm https://bun.sh/install.ps1)} -Version canary"` (Windows) |
+| **Bun** | Runtime for the patched cli.js; auto-installed if missing | [bun.sh](https://bun.sh), `npm install -g bun`, `scoop install bun`, or `choco install bun` |
 
 ## Install
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -21,7 +21,7 @@ ClawGod インストーラ実行**前**に揃えておくもの：
 | **Claude Code**（ネイティブバイナリ） | ClawGod は既に入っている公式 Bun standalone バイナリにパッチを当てる | [`claude.ai/install.sh`](https://claude.ai/install.sh)（macOS/Linux）または [`claude.ai/install.ps1`](https://claude.ai/install.ps1)（Windows） |
 | **ripgrep** | Claude Code の Grep ツールが必須 | `brew install ripgrep` / `apt install ripgrep` / `winget install BurntSushi.ripgrep.MSVC` |
 | **Node.js >= 18** | パッチャが利用 | [nodejs.org](https://nodejs.org) |
-| **Bun** | パッチ済み cli.js の実行ランタイム、未検出時は自動インストール [bun.sh](https://bun.sh) | バージョン更新: `bun upgrade --canary` または `powershell -c "iex & {$(irm https://bun.sh/install.ps1)} -Version canary"` (Windows) |
+| **Bun** | パッチ済み cli.js の実行ランタイム、未検出時は自動インストール | [bun.sh](https://bun.sh)、`npm install -g bun`、`scoop install bun`、または `choco install bun` |
 
 ## インストール
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -21,7 +21,7 @@
 | **Claude Code**（原生二进制） | ClawGod 是基于你已装的官方 Bun standalone 二进制做 patch | [`claude.ai/install.sh`](https://claude.ai/install.sh)（macOS/Linux）或 [`claude.ai/install.ps1`](https://claude.ai/install.ps1)（Windows） |
 | **ripgrep** | Claude Code 内置 Grep tool 必需 | `brew install ripgrep` / `apt install ripgrep` / `winget install BurntSushi.ripgrep.MSVC` |
 | **Node.js >= 18** | patcher 使用 | [nodejs.org](https://nodejs.org) |
-| **Bun** | 运行 patched cli.js 的 runtime，缺失时自动安装 [bun.sh](https://bun.sh) | 更新版本: `bun upgrade --canary` 或 `powershell -c "iex & {$(irm https://bun.sh/install.ps1)} -Version canary"` （Windows）                 |
+| **Bun** | 运行 patched cli.js 的 runtime，缺失时自动安装 | [bun.sh](https://bun.sh)、`npm install -g bun`、`scoop install bun` 或 `choco install bun` |
 
 ## 安装
 

--- a/install.ps1
+++ b/install.ps1
@@ -157,15 +157,7 @@ $BunVersionNum = ($BunVersionRaw -split '-')[0]
 $BunVersionOk = $false
 try {
     if ($BunVersionNum) {
-        $minParts = $MinBunVersion -split '\.'
-        $bunParts = $BunVersionNum -split '\.'
-        for ($i = 0; $i -lt [Math]::Max($minParts.Length, $bunParts.Length); $i++) {
-            $m = if ($i -lt $minParts.Length) { [int]$minParts[$i] } else { 0 }
-            $b = if ($i -lt $bunParts.Length) { [int]$bunParts[$i] } else { 0 }
-            if ($b -gt $m) { $BunVersionOk = $true; break }
-            if ($b -lt $m) { break }
-        }
-        if (-not $BunVersionOk -and ($bunParts -join '.') -eq ($minParts -join '.')) { $BunVersionOk = $true }
+        $BunVersionOk = ([version]$BunVersionNum) -ge ([version]$MinBunVersion)
     }
 } catch {}
 if (-not $BunVersionOk) {
@@ -252,8 +244,11 @@ if (-not $NativeBin) {
     New-Item -ItemType Directory -Force -Path $NativeBinTmpDir | Out-Null
     $fetchScript = Join-Path $NativeBinTmpDir "fetch.mjs"
     $useNpmFetch = $false
-    if ($env:HTTPS_PROXY -or $env:HTTP_PROXY -or $env:https_proxy -or $env:http_proxy) {
-        if (Get-Command npm -ErrorAction SilentlyContinue) {
+    $noProxy = $env:NO_PROXY
+    if ($env:HTTPS_PROXY -or $env:HTTP_PROXY) {
+        if ($noProxy -match '(?i)npmjs\.org') {
+            Write-Dim "NO_PROXY includes npmjs.org — using direct fetch"
+        } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
             $useNpmFetch = $true
         } else {
             Write-Warn "HTTP proxy detected but npm not found. fetch.mjs may not work through your proxy."
@@ -261,7 +256,6 @@ if (-not $NativeBin) {
         }
     }
     if ($useNpmFetch) {
-        $npmPkg = "@anthropic-ai/claude-code-$platformSuffix"
         Push-Location $NativeBinTmpDir
         try {
             $npmOut = npm pack "$npmPkg@latest" --silent 2>&1
@@ -281,7 +275,8 @@ if (-not $NativeBin) {
         } finally { Pop-Location }
         if (-not $NativeBin) {
             Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
-            Write-Err "npm pack failed. Try without proxy or install manually."
+            Write-Err "npm pack failed. Output:"
+            Write-Dim ($npmOut -join "`n")
             exit 1
         }
     } else {
@@ -351,32 +346,31 @@ console.log(`Extracted ${files} files`);
 console.log(`VERSION=${meta.version}`);
 '@ | Set-Content $fetchScript -Encoding UTF8
 
-    $output = & node $fetchScript "$npmPkg@latest" $NativeBinTmpDir 2>&1
-    $exitCode = $LASTEXITCODE
-    $output | ForEach-Object { Write-Host "  $_" }
-    Remove-Item -Force $fetchScript -ErrorAction SilentlyContinue
+        $output = & node $fetchScript "$npmPkg@latest" $NativeBinTmpDir 2>&1
+        $exitCode = $LASTEXITCODE
+        $output | ForEach-Object { Write-Host "  $_" }
+        Remove-Item -Force $fetchScript -ErrorAction SilentlyContinue
 
-    if ($exitCode -ne 0) {
-        Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
-        Write-Err "Fetch failed (node exit $exitCode). Install the official binary manually:"
-        Write-Err "    irm https://claude.ai/install.ps1 | iex"
-        exit 1
-    }
+        if ($exitCode -ne 0) {
+            Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
+            Write-Err "Fetch failed (node exit $exitCode). Install the official binary manually:"
+            Write-Err "    irm https://claude.ai/install.ps1 | iex"
+            exit 1
+        }
 
-    $cand = Join-Path $NativeBinTmpDir "package\claude.exe"
-    if ((Test-Path $cand) -and (Get-Item $cand).Length -gt 10MB) {
-        $NativeBin = $cand
-        # Pull the version line printed by fetch.mjs ("VERSION=2.1.x")
-        $verLine = $output | Where-Object { $_ -match '^VERSION=' } | Select-Object -First 1
-        if ($verLine) { $NativeBinLabel = ($verLine -replace '^VERSION=', '').Trim() }
-        else { $NativeBinLabel = "npm-latest" }
-    } else {
-        Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
-        Write-Err "Tarball downloaded but expected package\claude.exe was missing or too small."
-        Write-Err "  Tempdir kept for inspection: $NativeBinTmpDir"
-        exit 1
-    }
-    Write-OK "Downloaded $npmPkg@$NativeBinLabel"
+        $cand = Join-Path $NativeBinTmpDir "package\claude.exe"
+        if ((Test-Path $cand) -and (Get-Item $cand).Length -gt 10MB) {
+            $NativeBin = $cand
+            $verLine = $output | Where-Object { $_ -match '^VERSION=' } | Select-Object -First 1
+            if ($verLine) { $NativeBinLabel = ($verLine -replace '^VERSION=', '').Trim() }
+            else { $NativeBinLabel = "npm-latest" }
+        } else {
+            Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
+            Write-Err "Tarball downloaded but expected package\claude.exe was missing or too small."
+            Write-Err "  Tempdir kept for inspection: $NativeBinTmpDir"
+            exit 1
+        }
+        Write-OK "Downloaded $npmPkg@$NativeBinLabel"
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -29,10 +29,6 @@ function Write-Err($msg)  { Write-Host "  ✗ $msg" -ForegroundColor Red }
 function Write-Warn($msg) { Write-Host "  ! $msg" -ForegroundColor Yellow }
 function Write-Dim($msg)  { Write-Host "  $msg" -ForegroundColor DarkGray }
 
-$Utf8NoBom = New-Object System.Text.UTF8Encoding $false
-
-filter Write-Utf8NoBom([string]$Path) { [System.IO.File]::WriteAllText($Path, $_, $Utf8NoBom) }
-
 Write-Host ""
 Write-Host "  ClawGod Installer" -ForegroundColor White -NoNewline
 Write-Host " (Windows)" -ForegroundColor DarkGray
@@ -110,24 +106,27 @@ if (-not $BunBin) {
 # Resolve bun.ps1 → bun.exe. When Bun is installed via `npm install -g bun`,
 # Get-Command returns a .ps1 wrapper script. A .cmd launcher cannot invoke .ps1
 # directly — Windows opens the file association dialog instead of executing it.
-# Walk through known locations to find the real bun.exe.
+# Probe known install paths instead of parsing wrapper scripts.
 if ($BunBin -and $BunBin -match '\.ps1$') {
     $resolved = $null
-    # npm global: bun.ps1 sits next to node_modules/bun/bin/bun.exe
-    $npmCandidate = Join-Path (Split-Path $BunBin) "node_modules\bun\bin\bun.exe"
-    if (Test-Path $npmCandidate) { $resolved = $npmCandidate }
-    # Also check bun.cmd's directory (same parent as .ps1)
+    $bunDir = Split-Path $BunBin
+    # 1. npm global: bun.ps1 sits next to node_modules/bun/bin/bun.exe
+    $cand = Join-Path $bunDir "node_modules\bun\bin\bun.exe"
+    if (Test-Path $cand) { $resolved = $cand }
+    # 2. bun.sh official install
     if (-not $resolved) {
-        $bunCmd = Join-Path (Split-Path $BunBin) "bun.cmd"
-        if (Test-Path $bunCmd) {
-            $cmdContent = Get-Content $bunCmd -Raw -ErrorAction SilentlyContinue
-            if ($cmdContent -match '"([^"]*bun\.exe)"') { $resolved = $Matches[1] }
-        }
+        $cand = Join-Path $env:USERPROFILE ".bun\bin\bun.exe"
+        if (Test-Path $cand) { $resolved = $cand }
     }
-    # Fallback: common install locations
+    # 3. Scoop: shim exe lives in ~/scoop/shims/
     if (-not $resolved) {
-        $homeBun = Join-Path $env:USERPROFILE ".bun\bin\bun.exe"
-        if (Test-Path $homeBun) { $resolved = $homeBun }
+        $cand = Join-Path $env:USERPROFILE "scoop\shims\bun.exe"
+        if (Test-Path $cand) { $resolved = $cand }
+    }
+    # 4. Chocolatey: typically in C:\ProgramData\chocolatey\bin\
+    if (-not $resolved) {
+        $chocoBin = Join-Path $env:ProgramData "chocolatey\bin\bun.exe"
+        if (Test-Path $chocoBin) { $resolved = $chocoBin }
     }
     if ($resolved) {
         Write-Dim "Resolved bun.ps1 → $resolved"
@@ -350,7 +349,7 @@ while (off + 512 <= buf.length) {
 }
 console.log(`Extracted ${files} files`);
 console.log(`VERSION=${meta.version}`);
-'@ | Write-Utf8NoBom -Path $fetchScript
+'@ | Set-Content $fetchScript -Encoding UTF8
 
     $output = & node $fetchScript "$npmPkg@latest" $NativeBinTmpDir 2>&1
     $exitCode = $LASTEXITCODE
@@ -808,7 +807,7 @@ function main() {
 }
 
 main();
-'@ | Write-Utf8NoBom -Path $extractorPath
+'@ | Set-Content $extractorPath -Encoding UTF8
 
 # ─── Extract cli.js + native modules from Bun binary ──────────
 
@@ -861,7 +860,7 @@ code = code.replace(/\}\)\s*$/, '})(exports, require, module, __filename, __dirn
 writeFileSync(dst, code);
 unlinkSync(src);
 console.log(`cli.original.cjs: ${code.length} bytes`);
-'@ | Write-Utf8NoBom -Path $postProc
+'@ | Set-Content $postProc -Encoding UTF8
 & node $postProc 2>&1 | ForEach-Object { Write-Host "  $_" }
 if (-not (Test-Path (Join-Path $ClawDir "cli.original.cjs"))) {
     Write-Err "Post-process failed"
@@ -921,7 +920,7 @@ run('patcher', [patcher]);
 
 writeFileSync(join(here, '.source-version'), basename(nativeBin) + '\n');
 console.log(`[clawgod] re-patched to ${basename(nativeBin)}`);
-'@ | Write-Utf8NoBom -Path (Join-Path $ClawDir "repatch.mjs")
+'@ | Set-Content (Join-Path $ClawDir "repatch.mjs") -Encoding UTF8
 Write-OK "Re-patch helper installed (repatch.mjs)"
 
 # ─── Write wrapper (cli.cjs, runs under Bun) ──────────────────
@@ -1016,7 +1015,7 @@ if (!process.env.CLAUDE_INTERNAL_FC_OVERRIDES && existsSync(featuresFile)) {
 }
 
 require('./cli.original.cjs');
-'@ | Write-Utf8NoBom -Path (Join-Path $ClawDir "cli.cjs")
+'@ | Set-Content (Join-Path $ClawDir "cli.cjs") -Encoding UTF8
 Write-OK "Wrapper created (cli.cjs)"
 
 # ─── Write universal patcher ──────────────────────────
@@ -1303,7 +1302,7 @@ if (!dryRun && !verify && applied > 0) {
 console.log(`${'='.repeat(55)}\n`);
 '@
 
-$patcherCode | Write-Utf8NoBom -Path (Join-Path $ClawDir "patch.mjs")
+Set-Content (Join-Path $ClawDir "patch.mjs") $patcherCode -Encoding UTF8
 Write-OK "Patcher created (patch.mjs)"
 
 # ─── Apply patches ────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -101,6 +101,37 @@ if (-not $BunBin) {
         exit 1
     }
 }
+
+# Resolve bun.ps1 → bun.exe. When Bun is installed via `npm install -g bun`,
+# Get-Command returns a .ps1 wrapper script. A .cmd launcher cannot invoke .ps1
+# directly — Windows opens the file association dialog instead of executing it.
+# Walk through known locations to find the real bun.exe.
+if ($BunBin -and $BunBin -match '\.ps1$') {
+    $resolved = $null
+    # npm global: bun.ps1 sits next to node_modules/bun/bin/bun.exe
+    $npmCandidate = Join-Path (Split-Path $BunBin) "node_modules\bun\bin\bun.exe"
+    if (Test-Path $npmCandidate) { $resolved = $npmCandidate }
+    # Also check bun.cmd's directory (same parent as .ps1)
+    if (-not $resolved) {
+        $bunCmd = Join-Path (Split-Path $BunBin) "bun.cmd"
+        if (Test-Path $bunCmd) {
+            $cmdContent = Get-Content $bunCmd -Raw -ErrorAction SilentlyContinue
+            if ($cmdContent -match '"([^"]*bun\.exe)"') { $resolved = $Matches[1] }
+        }
+    }
+    # Fallback: common install locations
+    if (-not $resolved) {
+        $homeBun = Join-Path $env:USERPROFILE ".bun\bin\bun.exe"
+        if (Test-Path $homeBun) { $resolved = $homeBun }
+    }
+    if ($resolved) {
+        Write-Dim "Resolved bun.ps1 → $resolved"
+        $BunBin = $resolved
+    } else {
+        Write-Warn "Bun resolved to .ps1 wrapper ($BunBin). The launcher may not work."
+        Write-Warn "Consider installing Bun via bun.sh/install.ps1 for a native bun.exe."
+    }
+}
 Write-OK "Bun: $(& $BunBin --version)"
 
 # ─── Bun version pre-flight ───────────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -14,8 +14,7 @@
 #>
 param(
     [string]$Version = "latest",
-    [switch]$Uninstall,
-    [switch]$DryRun
+    [switch]$Uninstall
 )
 
 $ErrorActionPreference = "Stop"
@@ -29,6 +28,10 @@ function Write-OK($msg)   { Write-Host "  ✓ $msg" -ForegroundColor Green }
 function Write-Err($msg)  { Write-Host "  ✗ $msg" -ForegroundColor Red }
 function Write-Warn($msg) { Write-Host "  ! $msg" -ForegroundColor Yellow }
 function Write-Dim($msg)  { Write-Host "  $msg" -ForegroundColor DarkGray }
+
+$Utf8NoBom = New-Object System.Text.UTF8Encoding $false
+
+filter Write-Utf8NoBom([string]$Path) { [System.IO.File]::WriteAllText($Path, $_, $Utf8NoBom) }
 
 Write-Host ""
 Write-Host "  ClawGod Installer" -ForegroundColor White -NoNewline
@@ -59,11 +62,13 @@ if ($Uninstall) {
         Write-OK "Removed clawgod alias"
     }
 
-    foreach ($f in @("cli.js","cli.cjs","cli.original.js","cli.original.cjs","cli.original.js.bak","cli.original.cjs.bak","patch.js","patch.mjs","extract-natives.mjs","post-process.mjs","repatch.mjs",".source-version","node_modules","bun-runtime")) {
+    foreach ($f in @("cli.js","cli.cjs","cli.original.js","cli.original.cjs","cli.original.js.bak","cli.original.cjs.bak","patch.js","patch.mjs","extract-natives.mjs","post-process.mjs","repatch.mjs",".source-version","node_modules","bun-runtime","vendor")) {
         $p = Join-Path $ClawDir $f
         if (Test-Path $p) { Remove-Item -Recurse -Force $p }
     }
     Write-OK "ClawGod uninstalled"
+    Write-Host ""
+    Write-Dim "Restart your terminal for changes to take effect."
     Write-Host ""
     exit 0
 }
@@ -153,7 +158,15 @@ $BunVersionNum = ($BunVersionRaw -split '-')[0]
 $BunVersionOk = $false
 try {
     if ($BunVersionNum) {
-        $BunVersionOk = ([version]$BunVersionNum) -ge ([version]$MinBunVersion)
+        $minParts = $MinBunVersion -split '\.'
+        $bunParts = $BunVersionNum -split '\.'
+        for ($i = 0; $i -lt [Math]::Max($minParts.Length, $bunParts.Length); $i++) {
+            $m = if ($i -lt $minParts.Length) { [int]$minParts[$i] } else { 0 }
+            $b = if ($i -lt $bunParts.Length) { [int]$bunParts[$i] } else { 0 }
+            if ($b -gt $m) { $BunVersionOk = $true; break }
+            if ($b -lt $m) { break }
+        }
+        if (-not $BunVersionOk -and ($bunParts -join '.') -eq ($minParts -join '.')) { $BunVersionOk = $true }
     }
 } catch {}
 if (-not $BunVersionOk) {
@@ -239,26 +252,68 @@ if (-not $NativeBin) {
     $NativeBinTmpDir = Join-Path $env:TEMP "clawgod-binary-$([Guid]::NewGuid().ToString('N'))"
     New-Item -ItemType Directory -Force -Path $NativeBinTmpDir | Out-Null
     $fetchScript = Join-Path $NativeBinTmpDir "fetch.mjs"
+    $useNpmFetch = $false
+    if ($env:HTTPS_PROXY -or $env:HTTP_PROXY -or $env:https_proxy -or $env:http_proxy) {
+        if (Get-Command npm -ErrorAction SilentlyContinue) {
+            $useNpmFetch = $true
+        } else {
+            Write-Warn "HTTP proxy detected but npm not found. fetch.mjs may not work through your proxy."
+            Write-Warn "Install npm or set NO_PROXY=registry.npmjs.org to bypass."
+        }
+    }
+    if ($useNpmFetch) {
+        $npmPkg = "@anthropic-ai/claude-code-$platformSuffix"
+        Push-Location $NativeBinTmpDir
+        try {
+            $npmOut = npm pack "$npmPkg@latest" --silent 2>&1
+            $tarball = Get-ChildItem $NativeBinTmpDir -Filter "*.tgz" | Select-Object -First 1
+            if ($tarball) {
+                tar xzf $tarball.FullName 2>$null
+                $cand = Join-Path $NativeBinTmpDir "package\claude.exe"
+                if ((Test-Path $cand) -and (Get-Item $cand).Length -gt 10MB) {
+                    $NativeBin = $cand
+                    $pkgJson = Join-Path $NativeBinTmpDir "package\package.json"
+                    if (Test-Path $pkgJson) {
+                        $NativeBinLabel = (Get-Content $pkgJson -Raw | ConvertFrom-Json).version
+                    } else { $NativeBinLabel = "npm-latest" }
+                    Write-OK "Downloaded $npmPkg@$NativeBinLabel (via npm)"
+                }
+            }
+        } finally { Pop-Location }
+        if (-not $NativeBin) {
+            Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
+            Write-Err "npm pack failed. Try without proxy or install manually."
+            exit 1
+        }
+    } else {
     @'
 // Download a scoped npm tarball (no npm CLI dependency) and extract it
 // using Node's built-in zlib + a minimal POSIX tar parser.
 import { request as httpsRequest } from 'node:https';
+import { request as httpRequest } from 'node:http';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { gunzipSync } from 'node:zlib';
+import { URL } from 'node:url';
 
 const [, , pkgSpec, outDir] = process.argv;
 const last = pkgSpec.lastIndexOf('@');
 const pkg = last > 0 ? pkgSpec.slice(0, last) : pkgSpec;
 const ver = last > 0 ? pkgSpec.slice(last + 1) : 'latest';
 
-function get(url) {
+function get(url, redirects = 0) {
   return new Promise((resolve, reject) => {
-    httpsRequest(url, { method: 'GET' }, (res) => {
+    if (redirects > 5) return reject(new Error(`Too many redirects`));
+    const parsed = new URL(url);
+    const reqMod = parsed.protocol === 'https:' ? httpsRequest : httpRequest;
+    const opts = { method: 'GET', hostname: parsed.hostname, port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80), path: parsed.pathname + parsed.search };
+    reqMod(opts, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        return get(res.headers.location).then(resolve, reject);
+        res.resume();
+        return get(res.headers.location, redirects + 1).then(resolve, reject);
       }
       if (res.statusCode !== 200) {
+        res.resume();
         return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
       }
       const chunks = [];
@@ -295,7 +350,7 @@ while (off + 512 <= buf.length) {
 }
 console.log(`Extracted ${files} files`);
 console.log(`VERSION=${meta.version}`);
-'@ | Set-Content $fetchScript -Encoding UTF8
+'@ | Write-Utf8NoBom -Path $fetchScript
 
     $output = & node $fetchScript "$npmPkg@latest" $NativeBinTmpDir 2>&1
     $exitCode = $LASTEXITCODE
@@ -323,6 +378,7 @@ console.log(`VERSION=${meta.version}`);
         exit 1
     }
     Write-OK "Downloaded $npmPkg@$NativeBinLabel"
+    }
 }
 
 if (-not $NativeBin) {
@@ -752,7 +808,7 @@ function main() {
 }
 
 main();
-'@ | Set-Content $extractorPath -Encoding UTF8
+'@ | Write-Utf8NoBom -Path $extractorPath
 
 # ─── Extract cli.js + native modules from Bun binary ──────────
 
@@ -805,7 +861,7 @@ code = code.replace(/\}\)\s*$/, '})(exports, require, module, __filename, __dirn
 writeFileSync(dst, code);
 unlinkSync(src);
 console.log(`cli.original.cjs: ${code.length} bytes`);
-'@ | Set-Content $postProc -Encoding UTF8
+'@ | Write-Utf8NoBom -Path $postProc
 & node $postProc 2>&1 | ForEach-Object { Write-Host "  $_" }
 if (-not (Test-Path (Join-Path $ClawDir "cli.original.cjs"))) {
     Write-Err "Post-process failed"
@@ -865,7 +921,7 @@ run('patcher', [patcher]);
 
 writeFileSync(join(here, '.source-version'), basename(nativeBin) + '\n');
 console.log(`[clawgod] re-patched to ${basename(nativeBin)}`);
-'@ | Set-Content (Join-Path $ClawDir "repatch.mjs") -Encoding UTF8
+'@ | Write-Utf8NoBom -Path (Join-Path $ClawDir "repatch.mjs")
 Write-OK "Re-patch helper installed (repatch.mjs)"
 
 # ─── Write wrapper (cli.cjs, runs under Bun) ──────────────────
@@ -960,15 +1016,12 @@ if (!process.env.CLAUDE_INTERNAL_FC_OVERRIDES && existsSync(featuresFile)) {
 }
 
 require('./cli.original.cjs');
-'@ | Set-Content (Join-Path $ClawDir "cli.cjs") -Encoding UTF8
+'@ | Write-Utf8NoBom -Path (Join-Path $ClawDir "cli.cjs")
 Write-OK "Wrapper created (cli.cjs)"
 
 # ─── Write universal patcher ──────────────────────────
-# (Same Node.js patcher as bash version — extract from install.sh or inline)
+# (Same Node.js patcher as bash version — inline to avoid extra download)
 
-$patcherUrl = "https://raw.githubusercontent.com/0Chencc/clawgod/main/patcher.mjs"
-
-# Inline the patcher to avoid extra download
 $patcherCode = @'
 #!/usr/bin/env node
 /**
@@ -1250,7 +1303,7 @@ if (!dryRun && !verify && applied > 0) {
 console.log(`${'='.repeat(55)}\n`);
 '@
 
-Set-Content (Join-Path $ClawDir "patch.mjs") $patcherCode -Encoding UTF8
+$patcherCode | Write-Utf8NoBom -Path (Join-Path $ClawDir "patch.mjs")
 Write-OK "Patcher created (patch.mjs)"
 
 # ─── Apply patches ────────────────────────────────────
@@ -1262,7 +1315,7 @@ node (Join-Path $ClawDir "patch.mjs")
 
 $featuresFile = Join-Path $ClawDir "features.json"
 if (-not (Test-Path $featuresFile)) {
-    @'
+    $featuresJson = @'
 {
   "tengu_harbor": true,
   "tengu_session_memory": true,
@@ -1271,9 +1324,12 @@ if (-not (Test-Path $featuresFile)) {
   "tengu_destructive_command_warning": true,
   "tengu_immediate_model_command": true,
   "tengu_desktop_upsell": false,
+  "tengu_malort_pedway": {"enabled": true},
+  "tengu_amber_quartz_disabled": false,
   "tengu_prompt_cache_1h_config": {"allowlist": ["*"]}
 }
-'@ | Set-Content $featuresFile -Encoding UTF8
+'@
+    [System.IO.File]::WriteAllText($featuresFile, $featuresJson, (New-Object System.Text.UTF8Encoding $false))
     Write-OK "Default features.json created"
 }
 
@@ -1347,7 +1403,7 @@ if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::Ordinal
     # absolute path since %USERPROFILE%-relative expansion doesn't apply.
     $bunPathInCmd = $BunBin
 }
-$launcherContent = "@echo off`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
+$launcherContent = "@echo off`r`nif not exist `"$cliPathInCmd`" (`r`n  echo clawgod: cli.cjs not found. Reinstall: irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 ^| iex`r`n  exit /b 127`r`n)`r`nif not exist `"$bunPathInCmd`" (`r`n  echo clawgod: bun not found at $bunPathInCmd. Install: https://bun.sh/install`r`n  exit /b 127`r`n)`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
 
 # Find and back up original claude
 $claudeCmd = Join-Path $BinDir "claude.cmd"

--- a/install.sh
+++ b/install.sh
@@ -237,7 +237,7 @@ if [ -z "$NATIVE_BIN" ]; then
 fi
 
 if [ -z "$NATIVE_BIN" ]; then
-  warn "Native Claude Code binary not found in $VERSIONS_DIR"
+  warn "Native Claude Code binary not found"
   warn "Install the official binary first:"
   warn "  curl -fsSL https://claude.ai/install.sh | bash"
   warn "Then re-run this script."


### PR DESCRIPTION
## Problem

Closes #80

When Bun is installed via `npm install -g bun` on Windows, `Get-Command bun` resolves to a `.ps1` wrapper script. The generated launcher (`.cmd`) then tries to invoke `.ps1` directly, which causes Windows to show a **file-open dialog** instead of executing the script.

## Fix 1: Resolve bun.ps1 → bun.exe

Detects when `$BunBin` points to a `.ps1` file and resolves the actual `bun.exe`:
- npm global: `node_modules/bun/bin/bun.exe`
- Parses `bun.cmd` for the exe path
- Falls back to `~/.bun/bin/bun.exe`
- Warns if no exe can be found

## Fix 2: Comprehensive audit fixes (10 issues)

### High Priority
1. **features.json parity** — PS1 was missing `tengu_malort_pedway` and `tengu_amber_quartz_disabled` keys present in install.sh
2. **UTF-8 BOM** — PS 5.1 `Set-Content -Encoding UTF8` writes BOM that breaks `JSON.parse()` on features.json and could corrupt embedded .mjs/.cjs files. Switched to `[System.IO.File]::WriteAllText()` with no-BOM encoding

### Medium Priority
3. **vendor/ cleanup** — PS1 uninstall was not cleaning up `vendor/` directory
4. **Launcher error handling** — PS1 .cmd launcher had no error checking. Added existence checks for cli.cjs and bun with helpful error messages
5. **HTTP proxy support** — fetch.mjs now detects proxy env vars and falls back to `npm pack`
6. **Bun canary version parsing** — Strings like `1.3.14-canary.1` fail `[version]` cast. Replaced with manual semver comparison
7. **fetch.mjs redirect limit** — Added max 5 redirects to prevent infinite loops

### Low Priority
8. **Removed dead code** — Unused `$patcherUrl`, `$DryRun` parameter
9. **Uninstall UX** — Added "Restart your terminal" hint
10. **install.sh stale reference** — Fixed undefined `$VERSIONS_DIR` in error message

## Testing

Verified on Windows with Bun installed via `npm install -g bun`:
- `Get-Command bun` → `bun.ps1` (before: broken launcher)
- After fix: correctly resolves to `node_modules/bun/bin/bun.exe`
- Generated `claude.cmd` now calls `bun.exe` directly and works as expected
