### PR TITLE
feat(installer): add sidecar install mode

### DIFF
--- a/.github/workflows/compat-daily.yml
+++ b/.github/workflows/compat-daily.yml
@@ -12,10 +12,14 @@ on:
     branches: [main]
     paths:
       - install.sh
+      - install.ps1
+      - tests/**
       - .github/workflows/compat-daily.yml
   pull_request:
     paths:
       - install.sh
+      - install.ps1
+      - tests/**
       - .github/workflows/compat-daily.yml
 
 permissions:
@@ -85,6 +89,13 @@ jobs:
           bun --version
           node --version
           uname -a
+
+      - name: Run static installer tests
+        shell: bash
+        run: |
+          node tests/auto-mode-patterns.test.mjs
+          tests/sidecar-mode.test.sh
+          bash -n install.sh
 
       - name: Run install.sh (npm-fallback path)
         # No official Claude binary pre-installed → install.sh exercises

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Added a sidecar install mode for ClawGod:
+  - macOS/Linux: `install.sh --sidecar`
+  - Windows: `install.ps1 -Sidecar`
+- Sidecar mode installs only the explicit `clawgod` / `clawgod.cmd` launcher.
+- Sidecar mode leaves the native Claude Code command unchanged:
+  - does not overwrite `claude`
+  - does not remove `claude.exe`
+  - does not create or rely on `claude.orig`
+- Added `~/.clawgod/install-mode` so self-updates preserve the chosen install mode.
+- In sidecar mode, `clawgod update` refreshes the patched ClawGod copy while native `claude update` remains Anthropic's own updater.
+- Added installer regression tests for sidecar mode and current Auto-mode patch patterns.
+
+### Changed
+
+- Updated English, Chinese, and Japanese README files to document default install mode versus sidecar install mode.
+- Updated the compatibility workflow to run installer static tests on PRs that touch installer code.
+
+### Fixed
+
+- Updated the Auto-mode unlock patch for Claude Code `2.1.158`, where the previous single provider gate was split into an environment gate and a model-family gate.
+
+### Verified
+
+- `node tests/auto-mode-patterns.test.mjs`
+- `tests/sidecar-mode.test.sh`
+- `bash -n install.sh`
+- `git diff --check`
+- `bash install.sh --sidecar`
+- `clawgod --version` returned `2.1.158 (Claude Code)`
+- Confirmed native `claude` still resolved to `/opt/homebrew/bin/claude` after sidecar install.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Install these **before** running the ClawGod installer:
 
 ## Install
 
+Default install replaces the `claude` launcher so your normal command runs the patched build:
+
 **macOS / Linux:**
 ```bash
 curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash
@@ -33,6 +35,18 @@ curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.s
 **Windows (PowerShell):**
 ```powershell
 irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 | iex
+```
+
+Sidecar install leaves native Claude Code untouched and installs only the explicit `clawgod` command:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash -s -- --sidecar
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 -OutFile install.ps1; .\install.ps1 -Sidecar
 ```
 
 Green logo = patched. Orange logo = original.
@@ -87,6 +101,8 @@ claude.orig         # Original unpatched version (auto-backed-up)
 
 `clawgod` is unambiguous: on Windows where `claude.exe` may shadow `claude.cmd`, `clawgod.cmd` always works. Even after official self-update overwrites `claude`, `clawgod` keeps running the patched build.
 
+In sidecar mode, `claude` remains the official native command and only `clawgod` runs the patched copy.
+
 ## Configuration
 
 `~/.clawgod/provider.json` is auto-created on first run. Setting `apiKey` lets you skip OAuth entirely and point ClawGod at any Anthropic-compatible endpoint.
@@ -119,7 +135,9 @@ A `.source-version` stamp in `~/.clawgod/` records which native version was patc
 
 ## Update
 
-**Just run `claude update` as usual.** ClawGod patches the command to route through its own installer, which pulls the current Anthropic release from npm (`@anthropic-ai/claude-code-<plat>@latest`), re-extracts cli.js, re-applies patches, and rewrites the launcher. So the upstream update command keeps working the way you expect — you get the latest Claude, with patches still applied, in one step.
+In default mode, **just run `claude update` as usual.** ClawGod patches the command to route through its own installer, which pulls the current Anthropic release from npm (`@anthropic-ai/claude-code-<plat>@latest`), re-extracts cli.js, re-applies patches, and rewrites the launcher. So the upstream update command keeps working the way you expect — you get the latest Claude, with patches still applied, in one step.
+
+In sidecar mode, run `clawgod update` to update the patched copy. Native `claude update` remains Anthropic's own updater and does not touch ClawGod.
 
 If you'd rather invoke the installer directly (same effect, both paths fetch the same upstream release and re-patch):
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -25,6 +25,8 @@ ClawGod インストーラ実行**前**に揃えておくもの：
 
 ## インストール
 
+デフォルトインストールでは `claude` launcher を置き換え、通常の `claude` コマンドでパッチ済みビルドを実行します：
+
 **macOS / Linux:**
 ```bash
 curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash
@@ -33,6 +35,18 @@ curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.s
 **Windows (PowerShell):**
 ```powershell
 irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 | iex
+```
+
+Sidecar インストールではネイティブ Claude Code をそのまま残し、明示的な `clawgod` コマンドだけを追加します：
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash -s -- --sidecar
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 -OutFile install.ps1; .\install.ps1 -Sidecar
 ```
 
 緑のロゴ = パッチ適用済み。オレンジのロゴ = オリジナル。
@@ -87,6 +101,8 @@ claude.orig         # オリジナル未修正版（自動バックアップ）
 
 `clawgod` は曖昧さのないエントリポイントです：Windows で `claude.exe` が `claude.cmd` を覆い隠す場合でも `clawgod.cmd` は常に動作し、公式自動更新で `claude` が上書きされても `clawgod` はパッチ済みビルドを実行し続けます。
 
+Sidecar モードでは、`claude` は公式ネイティブコマンドのままで、`clawgod` だけがパッチ済みコピーを実行します。
+
 ## 設定
 
 初回起動時に `~/.clawgod/provider.json` が自動生成されます。`apiKey` を設定すれば **OAuth ログイン不要**で、Anthropic 互換エンドポイントに接続できます。
@@ -119,7 +135,9 @@ claude.orig         # オリジナル未修正版（自動バックアップ）
 
 ## アップデート
 
-**そのまま `claude update` を実行するだけで OK です。** ClawGod はこのコマンドを自身のインストーラへ流すようパッチしており、npm から Anthropic の現行リリース（`@anthropic-ai/claude-code-<plat>@latest`）を取得し、cli.js を再抽出、パッチを再適用、launcher を書き直します。そのため上流の `claude update` コマンドは期待通りに動作します——1 コマンドで最新の Claude を取得し、パッチも適用された状態を保てます。
+デフォルトモードでは、**そのまま `claude update` を実行するだけで OK です。** ClawGod はこのコマンドを自身のインストーラへ流すようパッチしており、npm から Anthropic の現行リリース（`@anthropic-ai/claude-code-<plat>@latest`）を取得し、cli.js を再抽出、パッチを再適用、launcher を書き直します。そのため上流の `claude update` コマンドは期待通りに動作します——1 コマンドで最新の Claude を取得し、パッチも適用された状態を保てます。
+
+Sidecar モードでは、`clawgod update` でパッチ済みコピーを更新します。ネイティブの `claude update` は Anthropic 公式 updater のままで、ClawGod には影響しません。
 
 直接インストーラを実行したい場合（効果は同じで、どちらも同じ上流リリースを取得してパッチを当て直します）：
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -25,6 +25,8 @@
 
 ## 安装
 
+默认安装会替换 `claude` launcher，让日常 `claude` 命令直接运行 patched 版本：
+
 **macOS / Linux:**
 ```bash
 curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash
@@ -33,6 +35,18 @@ curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.s
 **Windows (PowerShell):**
 ```powershell
 irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 | iex
+```
+
+旁路安装会保留原生 Claude Code，只安装显式的 `clawgod` 命令：
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash -s -- --sidecar
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 -OutFile install.ps1; .\install.ps1 -Sidecar
 ```
 
 绿色 Logo = 已 Patch。橙色 Logo = 原版。
@@ -87,6 +101,8 @@ claude.orig         # 原版未修改版本（自动备份）
 
 `clawgod` 是一个无歧义的入口：Windows 上即便 `claude.exe` 抢占了 `claude.cmd`，`clawgod.cmd` 始终生效；即便官方自动更新覆盖了 `claude`，`clawgod` 仍跑 patched 版本。
 
+旁路模式下，`claude` 保持官方原生命令不变，只有 `clawgod` 运行 patched 副本。
+
 ## 配置
 
 首次启动会自动生成 `~/.clawgod/provider.json`。填入 `apiKey` 即可**跳过 OAuth 登录**，对接任何 Anthropic 协议端点。
@@ -119,7 +135,9 @@ claude.orig         # 原版未修改版本（自动备份）
 
 ## 更新
 
-**直接照常跑 `claude update` 即可。** ClawGod 把这条命令 patch 成走自己的 installer——从 npm 拉 Anthropic 当前发布（`@anthropic-ai/claude-code-<plat>@latest`）、重新提取 cli.js、重新打补丁、重写 launcher。所以上游 `claude update` 命令对用户依然如常工作——一条命令拿到最新 Claude + 补丁仍然生效。
+默认模式下，**直接照常跑 `claude update` 即可。** ClawGod 把这条命令 patch 成走自己的 installer——从 npm 拉 Anthropic 当前发布（`@anthropic-ai/claude-code-<plat>@latest`）、重新提取 cli.js、重新打补丁、重写 launcher。所以上游 `claude update` 命令对用户依然如常工作——一条命令拿到最新 Claude + 补丁仍然生效。
+
+旁路模式下，运行 `clawgod update` 更新 patched 副本。原生 `claude update` 仍然是 Anthropic 官方 updater，不会影响 ClawGod。
 
 如果你想直接调 installer（效果一样，两条路径都会拉同一个上游 release 并重新 patch）:
 

--- a/install.ps1
+++ b/install.ps1
@@ -4,16 +4,18 @@
     ClawGod Installer for Windows
 .DESCRIPTION
     Downloads Claude Code from npm, applies feature unlock patches,
-    and replaces the 'claude' command with the patched version.
+    and installs patched launchers.
 .EXAMPLE
     irm clawgod.0chen.cc/install.ps1 | iex
     # or
     .\install.ps1
     .\install.ps1 -Version 2.1.89
+    .\install.ps1 -Sidecar
     .\install.ps1 -Uninstall
 #>
 param(
     [string]$Version = "latest",
+    [switch]$Sidecar,
     [switch]$Uninstall
 )
 
@@ -21,6 +23,7 @@ $ErrorActionPreference = "Stop"
 
 $ClawDir = Join-Path $env:USERPROFILE ".clawgod"
 $BinDir  = Join-Path $env:USERPROFILE ".local\bin"
+$InstallMode = if ($Sidecar) { "sidecar" } else { "hijack" }
 
 # ─── Colors ───────────────────────────────────────────
 
@@ -58,7 +61,7 @@ if ($Uninstall) {
         Write-OK "Removed clawgod alias"
     }
 
-    foreach ($f in @("cli.js","cli.cjs","cli.original.js","cli.original.cjs","cli.original.js.bak","cli.original.cjs.bak","patch.js","patch.mjs","extract-natives.mjs","post-process.mjs","repatch.mjs",".source-version","node_modules","bun-runtime","vendor")) {
+    foreach ($f in @("cli.js","cli.cjs","cli.original.js","cli.original.cjs","cli.original.js.bak","cli.original.cjs.bak","patch.js","patch.mjs","extract-natives.mjs","post-process.mjs","repatch.mjs",".source-version","install-mode","node_modules","bun-runtime","vendor")) {
         $p = Join-Path $ClawDir $f
         if (Test-Path $p) { Remove-Item -Recurse -Force $p }
     }
@@ -207,6 +210,7 @@ catch {
 
 New-Item -ItemType Directory -Force -Path $ClawDir | Out-Null
 New-Item -ItemType Directory -Force -Path $BinDir  | Out-Null
+Set-Content (Join-Path $ClawDir "install-mode") $InstallMode -Encoding ASCII
 
 $NativeBin = $null
 $NativeBinLabel = $null
@@ -1127,16 +1131,43 @@ const patches = [
     replacer: (m, fn) => `function ${fn}(){return!0}`,
   },
   {
-    // ≤v2.1.110: let Y=Dq();if(Y!=="firstParty"&&Y!=="anthropicAws")return!1;return/^claude-(opus|sonnet)-4-6/.test(K)
-    // v2.1.119+: same gate plus extra branches for claude-opus-4-7.
-    // v2.1.139+: gate moved inside function wuH(H){let $=R7(H),q=Wq();if(q!=="firstParty"&&q!=="anthropicAws")return!1;if($.includes("claude-3-")||...)return!0;return!1}
-    //            i.e. the `let` lifted to a comma-list before the if; the if-gate
-    //            itself is unchanged shape. We drop only the if-gate; downstream
-    //            model allow-list still runs and now accepts third-party calls.
-    name: 'Auto-mode unlock for third-party API',
+    // ≤v2.1.139: function wuH(H){let $=R7(H),q=Wq();if(q!=="firstParty"&&q!=="anthropicAws")return!1;if(...)return!0;return!1}
+    name: 'Auto-mode unlock for third-party API (legacy provider gate)',
     pattern: /if\(([\w$]+)!=="firstParty"&&\1!=="anthropicAws"\)return!1;/g,
     replacer: () => '',
-    sentinel: '!=="firstParty"&&',
+    validate: (match, code) => {
+      const pos = code.indexOf(match);
+      const nearby = code.substring(Math.max(0, pos - 500), pos + 500);
+      return nearby.includes('claude-opus-4-6') || nearby.includes('claude-opus-4-7');
+    },
+    optional: true,
+  },
+  {
+    // v2.1.158+: provider check moved into iH6(q), with env override
+    // CLAUDE_CODE_ENABLE_AUTO_MODE. Remove the call-site gate so third-party
+    // users reach the same model allow-list without setting an env var.
+    name: 'Auto-mode unlock for third-party API (env gate)',
+    pattern: /if\(![\w$]+\(([\w$]+)\)\)return!1;/g,
+    replacer: () => '',
+    validate: (match, code) => {
+      const pos = code.indexOf(match);
+      const nearby = code.substring(Math.max(0, pos - 500), pos + 500);
+      return nearby.includes('CLAUDE_CODE_ENABLE_AUTO_MODE') && nearby.includes('claude-opus-4-6');
+    },
+    optional: true,
+  },
+  {
+    // v2.1.158+: a second branch blocks third-party providers from the newer
+    // auto-mode model families even after the env gate is bypassed.
+    name: 'Auto-mode unlock for third-party API (model gate)',
+    pattern: /if\(([\w$]+)!=="firstParty"&&\1!=="anthropicAws"&&\([\s\S]{1,180}?\)\)return!1;/g,
+    replacer: () => '',
+    validate: (match, code) => {
+      const pos = code.indexOf(match);
+      const nearby = code.substring(Math.max(0, pos - 500), pos + 500);
+      return nearby.includes('CLAUDE_CODE_ENABLE_AUTO_MODE') && nearby.includes('claude-opus-4-6');
+    },
+    optional: true,
   },
   {
     // Redirect CLI `claude update` to clawgod self-update. Upstream's
@@ -1152,22 +1183,25 @@ const patches = [
     replacer: (m, prefix) => {
       // PowerShell 5.1's Invoke-WebRequest ignores HTTP_PROXY/HTTPS_PROXY env
       // (only reads IE system proxy). Read env explicitly and pass via -Proxy
-      // so it works on both PS 5.1 and PS 7. Use Invoke-RestMethod (irm) not
-      // Invoke-WebRequest (iwr): under -UseBasicParsing on PS 5.1, iwr's
-      // .Content is byte[] not string, so `iex (iwr -useb ...).Content`
-      // throws "Cannot convert System.Byte[] to System.String". irm always
-      // returns string in both versions. -EncodedCommand bypasses CLI
-      // arg-quoting; payload must be UTF-16LE base64.
+      // so it works on both PS 5.1 and PS 7. Download to a temp file instead
+      // of piping through iex so we can pass -Sidecar as a normal parameter.
+      // -EncodedCommand bypasses CLI arg-quoting; payload is UTF-16LE base64.
       const psScript =
         "$p=if($env:HTTPS_PROXY){$env:HTTPS_PROXY}elseif($env:HTTP_PROXY){$env:HTTP_PROXY}else{$null};" +
         "$u='https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1';" +
-        "if($p){iex(irm -Proxy $p $u)}else{iex(irm $u)}";
+        "$m=Join-Path $env:USERPROFILE '.clawgod\\install-mode';" +
+        "$s=(Test-Path $m)-and((Get-Content $m -Raw).Trim()-eq 'sidecar');" +
+        "$t=Join-Path $env:TEMP 'clawgod-install.ps1';" +
+        "if($p){iwr -UseBasicParsing -Proxy $p $u -OutFile $t}else{iwr -UseBasicParsing $u -OutFile $t};" +
+        "if($s){& $t -Sidecar}else{& $t}";
       const psB64 = Buffer.from(psScript, 'utf16le').toString('base64');
       return (
         prefix +
         `process.stderr.write("[clawgod] 'claude update' is handled by clawgod self-update.\\n[clawgod] To leave clawgod and use vanilla update: bash ~/.clawgod/install.sh --uninstall\\n[clawgod] Continuing now\\u2026\\n");` +
         `const _w=process.platform==='win32';` +
-        `const _c=_w?['powershell','-NoProfile','-EncodedCommand','${psB64}']:['bash','-c','curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash'];` +
+        `const _m=require('fs').existsSync(require('path').join(require('os').homedir(),'.clawgod','install-mode'))?require('fs').readFileSync(require('path').join(require('os').homedir(),'.clawgod','install-mode'),'utf8').trim():'';` +
+        `const _s=_m==='sidecar'?' --sidecar':'';` +
+        `const _c=_w?['powershell','-NoProfile','-EncodedCommand','${psB64}']:['bash','-c','curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash -s --'+_s];` +
         `const _r=require('child_process').spawnSync(_c[0],_c.slice(1),{stdio:'inherit'});` +
         `process.exit(_r.status||0);`
       );
@@ -1431,81 +1465,80 @@ if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::Ordinal
 }
 $launcherContent = "@echo off`r`nif not exist `"$cliPathInCmd`" (`r`n  echo clawgod: cli.cjs not found. Reinstall: irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 ^| iex`r`n  exit /b 127`r`n)`r`nif not exist `"$bunPathInCmd`" (`r`n  echo clawgod: bun not found at $bunPathInCmd. Install: https://bun.sh/install`r`n  exit /b 127`r`n)`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
 
-# Find and back up original claude
 $claudeCmd = Join-Path $BinDir "claude.cmd"
 $claudeExe = Join-Path $BinDir "claude.exe"
 $claudeOrigCmd = Join-Path $BinDir "claude.orig.cmd"
 $claudeOrigExe = Join-Path $BinDir "claude.orig.exe"
 
-# Check multiple locations for original claude
-$originalFound = $false
-foreach ($loc in @(
-    (Join-Path $BinDir "claude.exe"),
-    (Join-Path $BinDir "claude.cmd"),
-    (Join-Path $env:USERPROFILE ".local\share\claude\versions"),
-    (Join-Path $env:LOCALAPPDATA "Programs\claude-code")
-)) {
-    if (Test-Path $loc) {
-        # Back up .exe if exists and not already backed up
-        if ($loc -like "*.exe" -and -not (Test-Path $claudeOrigExe)) {
-            Copy-Item $loc $claudeOrigExe -Force
-            Write-OK "Original claude.exe backed up → claude.orig.exe"
-            $originalFound = $true
-        }
-        # Back up .cmd if exists and not already backed up
-        if ($loc -like "*.cmd" -and -not (Test-Path $claudeOrigCmd)) {
-            Copy-Item $loc $claudeOrigCmd -Force
-            Write-OK "Original claude.cmd backed up → claude.orig.cmd"
-            $originalFound = $true
-        }
-        # If it's a versions directory, find the latest exe
-        if (Test-Path $loc -PathType Container) {
-            $latestExe = Get-ChildItem $loc -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-            if ($latestExe -and -not (Test-Path $claudeOrigExe)) {
-                Copy-Item $latestExe.FullName $claudeOrigExe -Force
-                Write-OK "Original claude backed up → claude.orig.exe ($($latestExe.Name))"
+if ($InstallMode -eq "sidecar") {
+    Write-Dim "Sidecar mode: leaving native 'claude' unchanged"
+    $launcherContent | Set-Content (Join-Path $BinDir "clawgod.cmd") -Encoding Default
+    Write-OK "Command 'clawgod' → patched"
+} else {
+    # Check multiple locations for original claude
+    $originalFound = $false
+    foreach ($loc in @(
+        (Join-Path $BinDir "claude.exe"),
+        (Join-Path $BinDir "claude.cmd"),
+        (Join-Path $env:USERPROFILE ".local\share\claude\versions"),
+        (Join-Path $env:LOCALAPPDATA "Programs\claude-code")
+    )) {
+        if (Test-Path $loc) {
+            # Back up .exe if exists and not already backed up
+            if ($loc -like "*.exe" -and -not (Test-Path $claudeOrigExe)) {
+                Copy-Item $loc $claudeOrigExe -Force
+                Write-OK "Original claude.exe backed up → claude.orig.exe"
                 $originalFound = $true
             }
+            # Back up .cmd if exists and not already backed up
+            if ($loc -like "*.cmd" -and -not (Test-Path $claudeOrigCmd)) {
+                Copy-Item $loc $claudeOrigCmd -Force
+                Write-OK "Original claude.cmd backed up → claude.orig.cmd"
+                $originalFound = $true
+            }
+            # If it's a versions directory, find the latest exe
+            if (Test-Path $loc -PathType Container) {
+                $latestExe = Get-ChildItem $loc -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+                if ($latestExe -and -not (Test-Path $claudeOrigExe)) {
+                    Copy-Item $latestExe.FullName $claudeOrigExe -Force
+                    Write-OK "Original claude backed up → claude.orig.exe ($($latestExe.Name))"
+                    $originalFound = $true
+                }
+            }
+            break
         }
-        break
     }
-}
 
-# Clean up leftover timestamped/old exes from previous installs
-Get-ChildItem $BinDir -Filter "claude.*.exe" -ErrorAction SilentlyContinue |
-    Where-Object { $_.Name -ne "claude.orig.exe" } |
-    ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+    # Clean up leftover timestamped/old exes from previous installs
+    Get-ChildItem $BinDir -Filter "claude.*.exe" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne "claude.orig.exe" } |
+        ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
 
-# Remove claude.exe so .cmd takes precedence
-# Keep one backup as claude.orig.exe, discard the rest
-if (Test-Path $claudeExe) {
-    if (-not (Test-Path $claudeOrigExe)) {
-        Rename-Item $claudeExe $claudeOrigExe -Force
-        Write-OK "Renamed claude.exe → claude.orig.exe"
-    } else {
-        # Backup already exists — just remove the new claude.exe
-        try {
-            Remove-Item -Force $claudeExe
-        } catch {
-            # File locked (running process) — rename aside with timestamp
-            $ts = Get-Date -Format "yyyyMMddHHmmss"
-            Rename-Item $claudeExe "claude.$ts.exe" -Force -ErrorAction SilentlyContinue
+    # Remove claude.exe so .cmd takes precedence
+    # Keep one backup as claude.orig.exe, discard the rest
+    if (Test-Path $claudeExe) {
+        if (-not (Test-Path $claudeOrigExe)) {
+            Rename-Item $claudeExe $claudeOrigExe -Force
+            Write-OK "Renamed claude.exe → claude.orig.exe"
+        } else {
+            # Backup already exists — just remove the new claude.exe
+            try {
+                Remove-Item -Force $claudeExe
+            } catch {
+                # File locked (running process) — rename aside with timestamp
+                $ts = Get-Date -Format "yyyyMMddHHmmss"
+                Rename-Item $claudeExe "claude.$ts.exe" -Force -ErrorAction SilentlyContinue
+            }
+            Write-OK "Removed claude.exe (.cmd now takes priority)"
         }
-        Write-OK "Removed claude.exe (.cmd now takes priority)"
     }
-}
 
-
-# Write .cmd launcher for both 'claude' and the explicit 'clawgod' alias.
-# Why both:
-#  - claude.cmd may be shadowed by a claude.exe higher in PATH
-#  - clawgod.cmd has no .exe competitor, so it always works
-#  - User can invoke patched explicitly via `clawgod` regardless of which
-#    binary 'claude' resolves to
-foreach ($cmd in @("claude", "clawgod")) {
-    $launcherContent | Set-Content (Join-Path $BinDir "$cmd.cmd") -Encoding Default
+    # Write .cmd launcher for both 'claude' and the explicit 'clawgod' alias.
+    foreach ($cmd in @("claude", "clawgod")) {
+        $launcherContent | Set-Content (Join-Path $BinDir "$cmd.cmd") -Encoding Default
+    }
+    Write-OK "Commands 'claude' + 'clawgod' → patched"
 }
-Write-OK "Commands 'claude' + 'clawgod' → patched"
 
 # ─── Ensure BinDir is in PATH ─────────────────────────
 
@@ -1522,15 +1555,30 @@ if ($userPath -notlike "*$BinDir*") {
 Write-Host ""
 Write-Host "  ClawGod installed!" -ForegroundColor Green
 Write-Host ""
-Write-Dim "  claude            — Start patched Claude Code (green logo)"
-Write-Dim "  claude.orig       — Run original unpatched Claude Code"
+if ($InstallMode -eq "sidecar") {
+    Write-Dim "  clawgod           — Start patched Claude Code (green logo)"
+    Write-Dim "  claude            — Unchanged native Claude Code"
+} else {
+    Write-Dim "  claude            — Start patched Claude Code (green logo)"
+    Write-Dim "  claude.orig       — Run original unpatched Claude Code"
+    Write-Dim "  clawgod           — Explicit patched Claude Code alias"
+}
 Write-Host ""
-Write-Dim "  Updates: 'claude update' is patched to route through this installer."
-Write-Dim "  Just run it as usual — pulls latest Anthropic release + re-patches"
-Write-Dim "  in one step. To leave clawgod and use vanilla update:"
-Write-Dim "    bash ~/.clawgod/install.sh --uninstall"
+if ($InstallMode -eq "sidecar") {
+    Write-Dim "  Updates: run 'clawgod update' to refresh the patched sidecar."
+    Write-Dim "  Native 'claude update' remains Anthropic's own updater."
+} else {
+    Write-Dim "  Updates: 'claude update' is patched to route through this installer."
+    Write-Dim "  Just run it as usual — pulls latest Anthropic release + re-patches"
+    Write-Dim "  in one step. To leave clawgod and use vanilla update:"
+    Write-Dim "    . $ClawDir\install.ps1 -Uninstall"
+}
 Write-Host ""
-Write-Err "  If 'claude' still runs the old version, restart your terminal."
+if ($InstallMode -eq "sidecar") {
+    Write-Err "  If 'clawgod' is not found, restart your terminal."
+} else {
+    Write-Err "  If 'claude' still runs the old version, restart your terminal."
+}
 Write-Host ""
 Write-Dim "  Config: ~/.clawgod/provider.json"
 Write-Dim "  Flags:  ~/.clawgod/features.json"

--- a/install.sh
+++ b/install.sh
@@ -4,22 +4,24 @@ set -e
 # ─────────────────────────────────────────────────────────
 #  ClawGod Installer
 #
-#  Downloads Claude Code from npm, applies patches, replaces claude command
+#  Downloads Claude Code from npm, applies patches, and installs launchers
 #
 #  用法:
 #    curl -fsSL https://raw.githubusercontent.com/0Chencc/clawgod/main/install.sh | bash
 #    # 或
-#    bash install.sh [--version 2.1.89]
+#    bash install.sh [--version 2.1.89] [--sidecar]
 # ─────────────────────────────────────────────────────────
 
 CLAWGOD_DIR="$HOME/.clawgod"
 BIN_DIR="$HOME/.local/bin"
 VERSION="${CLAWGOD_VERSION:-latest}"
+INSTALL_MODE="hijack"
 
 # Parse args
 while [[ $# -gt 0 ]]; do
   case $1 in
     --version) VERSION="$2"; shift 2 ;;
+    --sidecar) INSTALL_MODE="sidecar"; shift ;;
     --uninstall) UNINSTALL=1; shift ;;
     *) shift ;;
   esac
@@ -61,7 +63,7 @@ if [ "$UNINSTALL" = "1" ]; then
       info "Removed ClawGod alias ($DIR/clawgod)"
     fi
   done
-  rm -rf "$CLAWGOD_DIR/node_modules" "$CLAWGOD_DIR/vendor" "$CLAWGOD_DIR/bun-runtime" "$CLAWGOD_DIR/cli.original.js" "$CLAWGOD_DIR/cli.original.js.bak" "$CLAWGOD_DIR/cli.original.cjs" "$CLAWGOD_DIR/cli.original.cjs.bak" "$CLAWGOD_DIR/cli.js" "$CLAWGOD_DIR/cli.cjs" "$CLAWGOD_DIR/patch.mjs" "$CLAWGOD_DIR/patch.js" "$CLAWGOD_DIR/extract-natives.mjs" "$CLAWGOD_DIR/post-process.mjs" "$CLAWGOD_DIR/repatch.mjs" "$CLAWGOD_DIR/.source-version"
+  rm -rf "$CLAWGOD_DIR/node_modules" "$CLAWGOD_DIR/vendor" "$CLAWGOD_DIR/bun-runtime" "$CLAWGOD_DIR/cli.original.js" "$CLAWGOD_DIR/cli.original.js.bak" "$CLAWGOD_DIR/cli.original.cjs" "$CLAWGOD_DIR/cli.original.cjs.bak" "$CLAWGOD_DIR/cli.js" "$CLAWGOD_DIR/cli.cjs" "$CLAWGOD_DIR/patch.mjs" "$CLAWGOD_DIR/patch.js" "$CLAWGOD_DIR/extract-natives.mjs" "$CLAWGOD_DIR/post-process.mjs" "$CLAWGOD_DIR/repatch.mjs" "$CLAWGOD_DIR/.source-version" "$CLAWGOD_DIR/install-mode"
   hash -r 2>/dev/null
   info "ClawGod uninstalled"
   echo ""
@@ -159,6 +161,7 @@ info "ripgrep: $(rg --version | head -1)"
 # Local binary detection is intentionally skipped — see policy note below.
 
 mkdir -p "$CLAWGOD_DIR" "$BIN_DIR"
+printf '%s\n' "$INSTALL_MODE" > "$CLAWGOD_DIR/install-mode"
 
 NATIVE_BIN=""
 NATIVE_BIN_LABEL=""
@@ -1004,16 +1007,43 @@ const patches = [
     replacer: (m, fn) => `function ${fn}(){return!0}`,
   },
   {
-    // ≤v2.1.110: let Y=Dq();if(Y!=="firstParty"&&Y!=="anthropicAws")return!1;return/^claude-(opus|sonnet)-4-6/.test(K)
-    // v2.1.119+: same gate plus extra branches for claude-opus-4-7.
-    // v2.1.139+: gate moved inside function wuH(H){let $=R7(H),q=Wq();if(q!=="firstParty"&&q!=="anthropicAws")return!1;if($.includes("claude-3-")||...)return!0;return!1}
-    //            i.e. the `let` lifted to a comma-list before the if; the if-gate
-    //            itself is unchanged shape. We drop only the if-gate; downstream
-    //            model allow-list still runs and now accepts third-party calls.
-    name: 'Auto-mode unlock for third-party API',
+    // ≤v2.1.139: function wuH(H){let $=R7(H),q=Wq();if(q!=="firstParty"&&q!=="anthropicAws")return!1;if(...)return!0;return!1}
+    name: 'Auto-mode unlock for third-party API (legacy provider gate)',
     pattern: /if\(([\w$]+)!=="firstParty"&&\1!=="anthropicAws"\)return!1;/g,
     replacer: () => '',
-    sentinel: '!=="firstParty"&&',
+    validate: (match, code) => {
+      const pos = code.indexOf(match);
+      const nearby = code.substring(Math.max(0, pos - 500), pos + 500);
+      return nearby.includes('claude-opus-4-6') || nearby.includes('claude-opus-4-7');
+    },
+    optional: true,
+  },
+  {
+    // v2.1.158+: provider check moved into iH6(q), with env override
+    // CLAUDE_CODE_ENABLE_AUTO_MODE. Remove the call-site gate so third-party
+    // users reach the same model allow-list without setting an env var.
+    name: 'Auto-mode unlock for third-party API (env gate)',
+    pattern: /if\(![\w$]+\(([\w$]+)\)\)return!1;/g,
+    replacer: () => '',
+    validate: (match, code) => {
+      const pos = code.indexOf(match);
+      const nearby = code.substring(Math.max(0, pos - 500), pos + 500);
+      return nearby.includes('CLAUDE_CODE_ENABLE_AUTO_MODE') && nearby.includes('claude-opus-4-6');
+    },
+    optional: true,
+  },
+  {
+    // v2.1.158+: a second branch blocks third-party providers from the newer
+    // auto-mode model families even after the env gate is bypassed.
+    name: 'Auto-mode unlock for third-party API (model gate)',
+    pattern: /if\(([\w$]+)!=="firstParty"&&\1!=="anthropicAws"&&\([\s\S]{1,180}?\)\)return!1;/g,
+    replacer: () => '',
+    validate: (match, code) => {
+      const pos = code.indexOf(match);
+      const nearby = code.substring(Math.max(0, pos - 500), pos + 500);
+      return nearby.includes('CLAUDE_CODE_ENABLE_AUTO_MODE') && nearby.includes('claude-opus-4-6');
+    },
+    optional: true,
   },
   {
     // CLI subcommand registered via commander chain:
@@ -1039,22 +1069,25 @@ const patches = [
     replacer: (m, prefix) => {
       // PowerShell 5.1's Invoke-WebRequest ignores HTTP_PROXY/HTTPS_PROXY env
       // (only reads IE system proxy). Read env explicitly and pass via -Proxy
-      // so it works on both PS 5.1 and PS 7. Use Invoke-RestMethod (irm) not
-      // Invoke-WebRequest (iwr): under -UseBasicParsing on PS 5.1, iwr's
-      // .Content is byte[] not string, so `iex (iwr -useb ...).Content`
-      // throws "Cannot convert System.Byte[] to System.String". irm always
-      // returns string in both versions. -EncodedCommand bypasses CLI
-      // arg-quoting; payload must be UTF-16LE base64.
+      // so it works on both PS 5.1 and PS 7. Download to a temp file instead
+      // of piping through iex so we can pass -Sidecar as a normal parameter.
+      // -EncodedCommand bypasses CLI arg-quoting; payload is UTF-16LE base64.
       const psScript =
         "$p=if($env:HTTPS_PROXY){$env:HTTPS_PROXY}elseif($env:HTTP_PROXY){$env:HTTP_PROXY}else{$null};" +
         "$u='https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1';" +
-        "if($p){iex(irm -Proxy $p $u)}else{iex(irm $u)}";
+        "$m=Join-Path $env:USERPROFILE '.clawgod\\install-mode';" +
+        "$s=(Test-Path $m)-and((Get-Content $m -Raw).Trim()-eq 'sidecar');" +
+        "$t=Join-Path $env:TEMP 'clawgod-install.ps1';" +
+        "if($p){iwr -UseBasicParsing -Proxy $p $u -OutFile $t}else{iwr -UseBasicParsing $u -OutFile $t};" +
+        "if($s){& $t -Sidecar}else{& $t}";
       const psB64 = Buffer.from(psScript, 'utf16le').toString('base64');
       return (
         prefix +
         `process.stderr.write("[clawgod] 'claude update' is handled by clawgod self-update.\\n[clawgod] To leave clawgod and use vanilla update: bash ~/.clawgod/install.sh --uninstall\\n[clawgod] Continuing now\\u2026\\n");` +
         `const _w=process.platform==='win32';` +
-        `const _c=_w?['powershell','-NoProfile','-EncodedCommand','${psB64}']:['bash','-c','curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash'];` +
+        `const _m=require('fs').existsSync(require('path').join(require('os').homedir(),'.clawgod','install-mode'))?require('fs').readFileSync(require('path').join(require('os').homedir(),'.clawgod','install-mode'),'utf8').trim():'';` +
+        `const _s=_m==='sidecar'?' --sidecar':'';` +
+        `const _c=_w?['powershell','-NoProfile','-EncodedCommand','${psB64}']:['bash','-c','curl -fsSL https://github.com/0Chencc/clawgod/releases/latest/download/install.sh | bash -s --'+_s];` +
         `const _r=require('child_process').spawnSync(_c[0],_c.slice(1),{stdio:'inherit'});` +
         `process.exit(_r.status||0);`
       );
@@ -1408,32 +1441,6 @@ if [ -z "$CLAUDE_BIN" ]; then
 fi
 CLAUDE_DIR=$(dirname "$CLAUDE_BIN")
 
-# Back up original claude (only once)
-if [ ! -e "$CLAUDE_BIN.orig" ]; then
-  if [ -L "$CLAUDE_BIN" ]; then
-    # Symlink (native install) — preserve target
-    NATIVE_BIN="$(readlink "$CLAUDE_BIN")"
-    ln -sf "$NATIVE_BIN" "$CLAUDE_BIN.orig"
-    info "Original claude backed up → claude.orig (→ $NATIVE_BIN)"
-  elif [ -f "$CLAUDE_BIN" ] && file "$CLAUDE_BIN" 2>/dev/null | grep -q "Mach-O\|ELF\|script"; then
-    # Binary or script (pnpm/npm global install)
-    cp "$CLAUDE_BIN" "$CLAUDE_BIN.orig"
-    info "Original claude backed up → claude.orig"
-  else
-    # Try versions dir as fallback
-    VERSIONS_DIR="$HOME/.local/share/claude/versions"
-    if [ -d "$VERSIONS_DIR" ]; then
-      NATIVE_BIN="$(ls -t "$VERSIONS_DIR"/* 2>/dev/null | while read f; do
-        file "$f" 2>/dev/null | grep -q "Mach-O\|ELF" && echo "$f" && break
-      done)" || true
-      if [ -n "$NATIVE_BIN" ]; then
-        ln -sf "$NATIVE_BIN" "$CLAUDE_BIN.orig"
-        info "Original claude backed up → claude.orig (→ $NATIVE_BIN)"
-      fi
-    fi
-  fi
-fi
-
 # Write launcher to the SAME directory where claude was found.
 # CRITICAL: `echo > $f` follows symlinks — if $CLAUDE_BIN is a symlink
 # (e.g. official ~/.local/bin/claude → ~/.local/share/claude/versions/X)
@@ -1449,13 +1456,43 @@ write_launcher() {
   chmod +x "$target"
 }
 
-write_launcher "$CLAUDE_BIN"
-info "Command 'claude' → patched ($CLAUDE_BIN)"
+if [ "$INSTALL_MODE" = "sidecar" ]; then
+  dim "Sidecar mode: leaving native 'claude' unchanged"
+else
+  # Back up original claude (only once)
+  if [ ! -e "$CLAUDE_BIN.orig" ]; then
+    if [ -L "$CLAUDE_BIN" ]; then
+      # Symlink (native install) — preserve target
+      NATIVE_BIN="$(readlink "$CLAUDE_BIN")"
+      ln -sf "$NATIVE_BIN" "$CLAUDE_BIN.orig"
+      info "Original claude backed up → claude.orig (→ $NATIVE_BIN)"
+    elif [ -f "$CLAUDE_BIN" ] && file "$CLAUDE_BIN" 2>/dev/null | grep -q "Mach-O\|ELF\|script"; then
+      # Binary or script (pnpm/npm global install)
+      cp "$CLAUDE_BIN" "$CLAUDE_BIN.orig"
+      info "Original claude backed up → claude.orig"
+    else
+      # Try versions dir as fallback
+      VERSIONS_DIR="$HOME/.local/share/claude/versions"
+      if [ -d "$VERSIONS_DIR" ]; then
+        NATIVE_BIN="$(ls -t "$VERSIONS_DIR"/* 2>/dev/null | while read f; do
+          file "$f" 2>/dev/null | grep -q "Mach-O\|ELF" && echo "$f" && break
+        done)" || true
+        if [ -n "$NATIVE_BIN" ]; then
+          ln -sf "$NATIVE_BIN" "$CLAUDE_BIN.orig"
+          info "Original claude backed up → claude.orig (→ $NATIVE_BIN)"
+        fi
+      fi
+    fi
+  fi
 
-# Also install to ~/.local/bin if claude was elsewhere (ensures PATH consistency)
-if [ "$CLAUDE_DIR" != "$BIN_DIR" ]; then
-  write_launcher "$BIN_DIR/claude"
-  dim "Also installed to $BIN_DIR/claude"
+  write_launcher "$CLAUDE_BIN"
+  info "Command 'claude' → patched ($CLAUDE_BIN)"
+
+  # Also install to ~/.local/bin if claude was elsewhere (ensures PATH consistency)
+  if [ "$CLAUDE_DIR" != "$BIN_DIR" ]; then
+    write_launcher "$BIN_DIR/claude"
+    dim "Also installed to $BIN_DIR/claude"
+  fi
 fi
 
 # Always expose an unambiguous `clawgod` alias alongside the `claude` override.
@@ -1490,15 +1527,30 @@ hash -r 2>/dev/null
 echo ""
 echo -e "  ${BOLD}${GREEN}ClawGod installed!${NC}"
 echo ""
-dim "  claude            — Start patched Claude Code (green logo)"
-dim "  claude.orig       — Run original unpatched Claude Code"
+if [ "$INSTALL_MODE" = "sidecar" ]; then
+  dim "  clawgod           — Start patched Claude Code (green logo)"
+  dim "  claude            — Unchanged native Claude Code"
+else
+  dim "  claude            — Start patched Claude Code (green logo)"
+  dim "  claude.orig       — Run original unpatched Claude Code"
+  dim "  clawgod           — Explicit patched Claude Code alias"
+fi
 echo ""
-dim "  Updates: 'claude update' is patched to route through this installer."
-dim "  Just run it as usual — pulls latest Anthropic release + re-patches"
-dim "  in one step. To leave clawgod and use vanilla update:"
-dim "    bash ~/.clawgod/install.sh --uninstall"
+if [ "$INSTALL_MODE" = "sidecar" ]; then
+  dim "  Updates: run 'clawgod update' to refresh the patched sidecar."
+  dim "  Native 'claude update' remains Anthropic's own updater."
+else
+  dim "  Updates: 'claude update' is patched to route through this installer."
+  dim "  Just run it as usual — pulls latest Anthropic release + re-patches"
+  dim "  in one step. To leave clawgod and use vanilla update:"
+  dim "    bash ~/.clawgod/install.sh --uninstall"
+fi
 echo ""
-warn "  If 'claude' still runs the old version, restart your terminal or run: hash -r"
+if [ "$INSTALL_MODE" = "sidecar" ]; then
+  warn "  If 'clawgod' is not found, restart your terminal or run: hash -r"
+else
+  warn "  If 'claude' still runs the old version, restart your terminal or run: hash -r"
+fi
 echo ""
 dim "  Config: ~/.clawgod/provider.json"
 dim "  Flags:  ~/.clawgod/features.json"

--- a/tests/auto-mode-patterns.test.mjs
+++ b/tests/auto-mode-patterns.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const installSh = readFileSync(new URL('../install.sh', import.meta.url), 'utf8');
+
+assert.match(installSh, /Auto-mode unlock for third-party API \(legacy provider gate\)/);
+assert.match(installSh, /Auto-mode unlock for third-party API \(env gate\)/);
+assert.match(installSh, /Auto-mode unlock for third-party API \(model gate\)/);
+
+const legacyProviderGate =
+  'function wuH(H){let $=R7(H),q=Wq();if(q!=="firstParty"&&q!=="anthropicAws")return!1;if($.includes("claude-3-")||$.includes("sonnet"))return!0;return!1}';
+
+const v2158AutoMode =
+  'function iH6(H){if(H==="firstParty"||H==="anthropicAws")return!0;return bH(process.env.CLAUDE_CODE_ENABLE_AUTO_MODE)}function lgH(H){{let _=$7(H),q=Wq();if(!iH6(q))return!1;if(_.includes("claude-3-")||_==="claude-opus-4-0"||_==="claude-opus-4-1"||_==="claude-opus-4-5"||_==="claude-sonnet-4-0"||_==="claude-sonnet-4-5"||_==="claude-haiku-4-5")return!1;if(q!=="firstParty"&&q!=="anthropicAws"&&(_==="claude-opus-4-6"||_.includes("sonnet")||_.includes("haiku")))return!1;return!0}return!1}';
+
+const legacyProviderPattern = /if\(([\w$]+)!=="firstParty"&&\1!=="anthropicAws"\)return!1;/g;
+const envGatePattern = /if\(![\w$]+\(([\w$]+)\)\)return!1;/g;
+const modelGatePattern = /if\(([\w$]+)!=="firstParty"&&\1!=="anthropicAws"&&\([\s\S]{1,180}?\)\)return!1;/g;
+
+assert.equal([...legacyProviderGate.matchAll(legacyProviderPattern)].length, 1);
+assert.equal([...v2158AutoMode.matchAll(envGatePattern)].length, 1);
+assert.equal([...v2158AutoMode.matchAll(modelGatePattern)].length, 1);

--- a/tests/sidecar-mode.test.sh
+++ b/tests/sidecar-mode.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq -- "$needle" "$ROOT/$file"; then
+    echo "missing in $file: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$ROOT/$file"; then
+    echo "unexpected in $file: $needle" >&2
+    exit 1
+  fi
+}
+
+bash -n "$ROOT/install.sh"
+
+assert_contains install.sh "--sidecar)"
+assert_contains install.sh 'INSTALL_MODE="sidecar"'
+assert_contains install.sh 'printf '"'"'%s\n'"'"' "$INSTALL_MODE" > "$CLAWGOD_DIR/install-mode"'
+assert_contains install.sh '"$CLAWGOD_DIR/install-mode"'
+assert_contains install.sh 'if [ "$INSTALL_MODE" = "sidecar" ]; then'
+assert_contains install.sh 'write_launcher "$BIN_DIR/clawgod"'
+sidecar_sh_block="$(perl -0ne 'if (/if \[ "\$INSTALL_MODE" = "sidecar" \]; then\n(.*?)\nelse\n/s) { print $1 }' "$ROOT/install.sh")"
+if grep -Fq 'write_launcher "$CLAUDE_BIN"' <<<"$sidecar_sh_block"; then
+  echo "sidecar branch must not write claude launcher" >&2
+  exit 1
+fi
+
+assert_contains install.ps1 '[switch]$Sidecar'
+assert_contains install.ps1 '$InstallMode = if ($Sidecar) { "sidecar" } else { "hijack" }'
+assert_contains install.ps1 'Set-Content (Join-Path $ClawDir "install-mode") $InstallMode'
+assert_contains install.ps1 'if ($InstallMode -eq "sidecar")'
+assert_contains install.ps1 'Set-Content (Join-Path $BinDir "clawgod.cmd")'
+
+assert_contains install.sh "install-mode"
+assert_contains install.ps1 "install-mode"


### PR DESCRIPTION
## Summary
- Add sidecar install mode so ClawGod can install only the explicit `clawgod` launcher without replacing native `claude`
- Persist install mode so `clawgod update` keeps sidecar installs sidecar
- Update auto-mode patching for Claude Code 2.1.158 and add installer regression tests

## Test Plan
- `node tests/auto-mode-patterns.test.mjs`
- `tests/sidecar-mode.test.sh`
- `bash -n install.sh`
- `git diff --check`
- `bash install.sh --sidecar`
- `clawgod --version`