### PR TITLE
fix(wrapper): monkey-patch process.execPath to fix find/grep/rg under Bun

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1455,7 +1455,7 @@ if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::Ordinal
     # absolute path since %USERPROFILE%-relative expansion doesn't apply.
     $bunPathInCmd = $BunBin
 }
-$launcherContent = "@echo off`r`nif not exist `"$cliPathInCmd`" (`r`n  echo clawgod: cli.cjs not found. Reinstall: irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 ^| iex`r`n  exit /b 127`r`n)`r`nif not exist `"$bunPathInCmd`" (`r`n  echo clawgod: bun not found at $bunPathInCmd. Install: https://bun.sh/install`r`n  exit /b 127`r`n)`r`nset CLAUDE_CODE_EXECPATH=%~dp0claude.orig.exe`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
+$launcherContent = "@echo off`r`nif not exist `"$cliPathInCmd`" (`r`n  echo clawgod: cli.cjs not found. Reinstall: irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 ^| iex`r`n  exit /b 127`r`n)`r`nif not exist `"$bunPathInCmd`" (`r`n  echo clawgod: bun not found at $bunPathInCmd. Install: https://bun.sh/install`r`n  exit /b 127`r`n)`r`nset `"CLAUDE_CODE_EXECPATH=%~dp0claude.orig.exe`"`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
 
 # Find and back up original claude
 $claudeCmd = Join-Path $BinDir "claude.cmd"

--- a/install.ps1
+++ b/install.ps1
@@ -1008,6 +1008,20 @@ if (!process.env.CLAUDE_INTERNAL_FC_OVERRIDES && existsSync(featuresFile)) {
   } catch {}
 }
 
+// Monkey-patch process.execPath: Anthropic's CLI uses process.execPath to
+// locate the native binary for shell wrappers (find→bfs, grep→ugrep, rg) and
+// subprocess spawning. Under Bun, process.execPath returns the Bun runtime
+// path, not the Claude native binary. The launcher script sets
+// CLAUDE_CODE_EXECPATH to claude.orig (the real binary) before exec'ing
+// Bun, so we use that as the source of truth.  See issue #100.
+const _realExecPath = process.env.CLAUDE_CODE_EXECPATH || process.execPath;
+if (_realExecPath !== process.execPath) {
+  Object.defineProperty(process, 'execPath', {
+    value: _realExecPath,
+    configurable: true,
+  });
+}
+
 require('./cli.original.cjs');
 '@ | Set-Content (Join-Path $ClawDir "cli.cjs") -Encoding UTF8
 Write-OK "Wrapper created (cli.cjs)"

--- a/install.ps1
+++ b/install.ps1
@@ -1455,7 +1455,7 @@ if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::Ordinal
     # absolute path since %USERPROFILE%-relative expansion doesn't apply.
     $bunPathInCmd = $BunBin
 }
-$launcherContent = "@echo off`r`nif not exist `"$cliPathInCmd`" (`r`n  echo clawgod: cli.cjs not found. Reinstall: irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 ^| iex`r`n  exit /b 127`r`n)`r`nif not exist `"$bunPathInCmd`" (`r`n  echo clawgod: bun not found at $bunPathInCmd. Install: https://bun.sh/install`r`n  exit /b 127`r`n)`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
+$launcherContent = "@echo off`r`nif not exist `"$cliPathInCmd`" (`r`n  echo clawgod: cli.cjs not found. Reinstall: irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 ^| iex`r`n  exit /b 127`r`n)`r`nif not exist `"$bunPathInCmd`" (`r`n  echo clawgod: bun not found at $bunPathInCmd. Install: https://bun.sh/install`r`n  exit /b 127`r`n)`r`nset CLAUDE_CODE_EXECPATH=%~dp0claude.orig.exe`r`n`"$bunPathInCmd`" `"$cliPathInCmd`" %*"
 
 # Find and back up original claude
 $claudeCmd = Join-Path $BinDir "claude.cmd"

--- a/install.sh
+++ b/install.sh
@@ -1402,6 +1402,18 @@ info "Bun loads cli.original.cjs"
 
 # ─── Replace claude command ───────────────────────────
 
+# Detect where claude is actually installed (supports native, npm, pnpm, yarn).
+# `command -v` is a POSIX builtin (works even on minimal images that no
+# longer ship `which`); `|| true` keeps a clean miss from tripping
+# `set -e` via the assignment's exit status under bash 5+.
+CLAUDE_BIN=$(command -v claude 2>/dev/null || true)
+if [ -z "$CLAUDE_BIN" ]; then
+  # No claude in PATH — use default location
+  CLAUDE_BIN="$BIN_DIR/claude"
+  dim "No existing claude found, installing to $BIN_DIR"
+fi
+CLAUDE_DIR=$(dirname "$CLAUDE_BIN")
+
 LAUNCHER_CONTENT="#!/bin/bash
 # clawgod launcher
 CLAWGOD_CLI=\"$CLAWGOD_DIR/cli.cjs\"
@@ -1420,20 +1432,9 @@ if [ ! -x \"\$BUN_BIN\" ]; then
   echo \"clawgod: install bun  curl -fsSL https://bun.sh/install | bash\" >&2
   exit 127
 fi
-export CLAUDE_CODE_EXECPATH=\"\$(dirname \"\$0\")/claude.orig\"
+export CLAUDE_CODE_EXECPATH=\"$CLAUDE_BIN.orig\"
 exec \"\$BUN_BIN\" \"\$CLAWGOD_CLI\" \"\$@\""
 
-# Detect where claude is actually installed (supports native, npm, pnpm, yarn).
-# `command -v` is a POSIX builtin (works even on minimal images that no
-# longer ship `which`); `|| true` keeps a clean miss from tripping
-# `set -e` via the assignment's exit status under bash 5+.
-CLAUDE_BIN=$(command -v claude 2>/dev/null || true)
-if [ -z "$CLAUDE_BIN" ]; then
-  # No claude in PATH — use default location
-  CLAUDE_BIN="$BIN_DIR/claude"
-  dim "No existing claude found, installing to $BIN_DIR"
-fi
-CLAUDE_DIR=$(dirname "$CLAUDE_BIN")
 
 # Back up original claude (only once)
 if [ ! -e "$CLAUDE_BIN.orig" ]; then

--- a/install.sh
+++ b/install.sh
@@ -899,6 +899,20 @@ if (!process.env.CLAUDE_INTERNAL_FC_OVERRIDES && existsSync(featuresFile)) {
   } catch {}
 }
 
+// Monkey-patch process.execPath: Anthropic's CLI uses process.execPath to
+// locate the native binary for shell wrappers (find→bfs, grep→ugrep, rg) and
+// subprocess spawning. Under Bun, process.execPath returns the Bun runtime
+// path, not the Claude native binary. The launcher script sets
+// CLAUDE_CODE_EXECPATH to claude.orig (the real ELF binary) before exec'ing
+// Bun, so we use that as the source of truth.  See issue #100.
+const _realExecPath = process.env.CLAUDE_CODE_EXECPATH || process.execPath;
+if (_realExecPath !== process.execPath) {
+  Object.defineProperty(process, 'execPath', {
+    value: _realExecPath,
+    configurable: true,
+  });
+}
+
 require('./cli.original.cjs');
 WRAPPER_EOF
 chmod +x "$CLAWGOD_DIR/cli.cjs"

--- a/install.sh
+++ b/install.sh
@@ -1420,6 +1420,7 @@ if [ ! -x \"\$BUN_BIN\" ]; then
   echo \"clawgod: install bun  curl -fsSL https://bun.sh/install | bash\" >&2
   exit 127
 fi
+export CLAUDE_CODE_EXECPATH=\"\$(dirname \"\$0\")/claude.orig\"
 exec \"\$BUN_BIN\" \"\$CLAWGOD_CLI\" \"\$@\""
 
 # Detect where claude is actually installed (supports native, npm, pnpm, yarn).


### PR DESCRIPTION
## Problem

Closes #100

在 Bun 运行时下，`process.execPath` 返回 Bun 路径（如 `~/.bun/bin/bun`），而非 Claude 原生 ELF 二进制。Anthropic 的 `cli.original.cjs` 在 `getEnvironmentOverrides()` 中使用 `process.execPath` 设置 `CLAUDE_CODE_EXECPATH`，导致 shell wrapper 函数将 `find`/`grep`/`rg` 分派到 Bun 而非原生多调用二进制，所有 `find` 和 `grep` 调用报错：

```
error: Invalid Argument '-S'    # find
error: Invalid Argument '-G'    # grep
```

## 根因

```
launcher → export CLAUDE_CODE_EXECPATH="claude.orig" ✅
         → exec bun cli.cjs

cli.cjs → require('./cli.original.cjs')

cli.original.cjs → O["CLAUDE_CODE_EXECPATH"] = process.execPath  ❌ 覆盖为 Bun 路径
```

已有的 patch.mjs 中 `"Shell integration → claude.orig"` 补丁修复了 shell snapshot 生成，但**运行时** `process.execPath` 仍然是 Bun 路径。

## Fix

在 `require('./cli.original.cjs')` 之前，将 `process.execPath` monkey-patch 为 launcher 已正确设置的 `CLAUDE_CODE_EXECPATH`：

```javascript
const _realExecPath = process.env.CLAUDE_CODE_EXECPATH || process.execPath;
if (_realExecPath !== process.execPath) {
  Object.defineProperty(process, 'execPath', {
    value: _realExecPath,
    configurable: true,
  });
}
```

仅在值不同时才 patch，保证非 Bun 环境（原生安装、Node.js）不受影响。

## 影响分析

已验证 `cli.original.cjs` 中全部 21 处 `process.execPath` 用法：

| 类别 | 数量 | 说明 |
|------|------|------|
| 安全/无影响 | 14 | 遥测、路径匹配、macOS 专用 |
| **改进** | 5 | 修复版本锁定(`_IH`)、版本清理、子进程生成 |
| **Bug 修复** | 1 | `getEnvironmentOverrides()` — 根因 |
| 安全 | 1 | 嵌入式 rg 分派 — `claude.orig` 支持多调用 |

### 附带修复的问题

- `_IH()` 版本锁定：Bun 路径不含 `/claude/versions/` → 锁被静默跳过。Patch 后正确识别。
- `hv8()` 版本检测：Bun 路径不在 versions 目录 → 返回 false。Patch 后正确返回 true。
- Tmux / Bridge Worker / 队友生成：全部使用正确的原生二进制路径。

## Testing

已在本地验证：

```bash
# 环境变量正确
$ echo $CLAUDE_CODE_EXECPATH
/home/huxiao/.local/bin/claude.orig  ✅ (之前: /home/huxiao/.bun/bin/bun)

# find 正常
$ find . -maxdepth 1 -name "*.md"
./CLAUDE.md  ✅ (之前: error: Invalid Argument '-S')

# grep 正常
$ echo "hello" | grep "hello"
hello  ✅ (之前: error: Invalid Argument '-G')

# 搜索功能正常
$ rg "test" --max-count 1  ✅
```

环境：Linux (WSL2), Claude Code 2.1.138, Bun 1.3.14-canary