### PR TITLE
fix(patcher): multitool grep/rg shim crashes with `bun -G` (issue #82)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1193,6 +1193,33 @@ const patches = [
     sentinel: '?"claude.exe":"claude")',
     optional: true,  // v2.1.88-era bundles compute the path differently
   },
+  {
+    // Companion to the #82 fix above. On the v2.1.140+ generator the emitted
+    // multitool shell function is:
+    //   local _cc_bin="${CLAUDE_CODE_EXECPATH:-}"
+    //   [[ -x $_cc_bin ]] || _cc_bin=<…>/claude.orig
+    //   if [[ ! -x $_cc_bin ]]; then command grep "$@"; return; fi
+    //   ARGV0=ugrep "$_cc_bin" -G …
+    // CLAUDE_CODE_EXECPATH is the PRIMARY; #82 only redirected the claude.orig
+    // *fallback*. But the clawgod launcher runs the patched cli.cjs **under
+    // bun**, so process.execPath — and thus CLAUDE_CODE_EXECPATH — is always
+    // the bun binary. bun is executable, so the primary `[[ -x ]]` test always
+    // wins, the claude.orig fallback is dead code, and the shim runs
+    // `bun -G …`, which bun rejects: `error: Invalid Argument '-G'`. Every
+    // grep/rg/etc. multitool call inside a Bash-tool shell fails — #82 never
+    // actually took effect on this shape. (issue #82)
+    //
+    // Fix: drop CLAUDE_CODE_EXECPATH from the shim entirely (under clawgod it
+    // is never anything but bun) and bind _cc_bin straight to the native
+    // claude.orig backup. The existing `[[ ! -x $_cc_bin ]]` guard then
+    // degrades to the real system grep/rg when claude.orig is absent (e.g. the
+    // npm-fallback install path, which retains no native binary) — strictly
+    // better than crashing out through bun.
+    name: 'Multitool shim: drop bun execPath, use native claude.orig',
+    pattern: /`  local _cc_bin="\\\$\{\$\{\w+\}:-\}"`,`  \[\[ -x \$_cc_bin \]\] \|\| _cc_bin=(\$\{[\w$]+\(\[[\w$]*\]\)\})`/g,
+    replacer: (m, backupInterp) => '`  local _cc_bin=' + backupInterp + '`',
+    optional: true,  // generator shape varies across versions
+  },
 ];
 
 // ─── Main ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Completes the #82 multitool-dispatch fix. On the current Claude CLI (v2.1.140+ shell-integration generator), bare `grep`/`rg`/etc. inside a Bash-tool shell fail with:

```
error: Invalid Argument '-G'
Bun is a fast JavaScript runtime, package manager, bundler, and test runner.
...
```

## Root cause

The generated shim is:

```sh
local _cc_bin="${CLAUDE_CODE_EXECPATH:-}"
[[ -x $_cc_bin ]] || _cc_bin=<…>/claude.orig
if [[ ! -x $_cc_bin ]]; then command grep "$@"; return; fi
ARGV0=ugrep "$_cc_bin" -G …
```

`CLAUDE_CODE_EXECPATH` is the **primary**; #82 only redirected the `claude.orig` **fallback**. But the clawgod launcher runs the patched `cli.cjs` *under bun*, so `process.execPath` — and therefore `CLAUDE_CODE_EXECPATH` — is always the bun binary. bun is executable, so the primary `[[ -x ]]` test always wins and the shim runs `bun -G …`, which bun rejects. The `claude.orig` fallback is dead code; #82 never executes on this shape.

## Fix

Drop `CLAUDE_CODE_EXECPATH` from the generated shim (under clawgod it is never anything but bun) and bind `_cc_bin` straight to the native `claude.orig` backup:

```sh
local _cc_bin=<…>/claude.orig
if [[ ! -x $_cc_bin ]]; then command grep "$@"; return; fi
ARGV0=ugrep "$_cc_bin" -G …
```

When `claude.orig` is present the dispatch reaches a real binary that honors `argv[0]`; when it is absent the existing guard degrades to the **system** `grep`/`rg` — strictly better than crashing through bun.

The patch is `optional` (the generator shape varies across CLI versions), so it never trips the compat-daily "0 failed" gate when upstream reshapes the emitter.

## Testing

- `bash -n install.sh` ✓ and `node --check` on the emitted `patch.mjs` ✓
- Ran the emitted `patch.mjs` against a real extracted `cli.original.cjs`: the new patch applies (`✅ 1 replacement`) and the resulting shim is `local _cc_bin=<claude.orig>` with no `CLAUDE_CODE_EXECPATH`.
- Simulated the patched shim in zsh and bash: `grep` match → exit 0, no-match → exit 1, recursive file search works; `ARGV0=ugrep <native> -G …` returns correct results.
- Verified live on macOS in a real Claude Code session after re-patch: bare `grep` works.

## Out of scope (related follow-ups)

While debugging I hit two install-side gaps that leave `claude.orig` *unavailable* on some machines. This PR makes the shim degrade gracefully in those cases (system grep/rg), but the bundled ripgrep won't be used:

1. **npm-fallback installs retain no native binary.** `$NATIVE_BIN` is downloaded into a tempdir that is `rm -rf`'d after extraction (`install.sh` ~L746), and the `claude.orig` backup (~L1422) is created from `command -v claude`, not `$NATIVE_BIN`. On a fresh machine there is no native binary left to dispatch to.
2. **Multi-install path mismatch.** The backup is written next to `command -v claude`; if that resolves to a different install than the launcher dir the shim computes (e.g. a coexisting IDE-bundled `claude` earlier in `PATH`), `claude.orig` lands somewhere the shim does not look.

Happy to follow up on either (e.g. symlink `claude.orig` → `$NATIVE_BIN` before the tempdir is cleaned) if you'd like — kept this PR to the shim fix, which resolves the hard crash universally.