### PR TITLE
fix: add missing ANSI green theme patches for non-truecolor terminals

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1582,6 +1582,31 @@ const patches = [
     replacer: () => '#22c55e',
   },
   {
+    name: 'Theme claude color → green (ANSI)',
+    pattern: /claude:"ansi:redBright"/g,
+    replacer: () => 'claude:"ansi:greenBright"',
+  },
+  {
+    name: 'Shimmer → green (ANSI)',
+    pattern: /claudeShimmer:"ansi:yellowBright"/g,
+    replacer: () => 'claudeShimmer:"ansi:greenBright"',
+  },
+  {
+    name: 'Brief label claude color → green (RGB dark)',
+    pattern: /briefLabelClaude:"rgb\(215,119,87\)"/g,
+    replacer: () => 'briefLabelClaude:"rgb(34,197,94)"',
+  },
+  {
+    name: 'Brief label claude color → green (RGB light)',
+    pattern: /briefLabelClaude:"rgb\(255,153,51\)"/g,
+    replacer: () => 'briefLabelClaude:"rgb(22,163,74)"',
+  },
+  {
+    name: 'Brief label claude color → green (ANSI)',
+    pattern: /briefLabelClaude:"ansi:redBright"/g,
+    replacer: () => 'briefLabelClaude:"ansi:greenBright"',
+  },
+  {
     name: 'macOS Cmd+V image paste fallback to clipboard read',
     pattern: /if\(([\w$]+)\.length===0&&([\w$]+)\.length>0\)([\w$]+)\("input_image_drag","read_failed"\),([\w$]+)\.push\(\.\.\.\2\)/g,
     replacer: (m, L, R, at, D) =>

--- a/install.sh
+++ b/install.sh
@@ -1497,6 +1497,31 @@ const patches = [
     pattern: /#da7756/g,
     replacer: () => '#22c55e',
   },
+  {
+    name: 'Theme claude color → green (ANSI)',
+    pattern: /claude:"ansi:redBright"/g,
+    replacer: () => 'claude:"ansi:greenBright"',
+  },
+  {
+    name: 'Shimmer → green (ANSI)',
+    pattern: /claudeShimmer:"ansi:yellowBright"/g,
+    replacer: () => 'claudeShimmer:"ansi:greenBright"',
+  },
+  {
+    name: 'Brief label claude color → green (RGB dark)',
+    pattern: /briefLabelClaude:"rgb\(215,119,87\)"/g,
+    replacer: () => 'briefLabelClaude:"rgb(34,197,94)"',
+  },
+  {
+    name: 'Brief label claude color → green (RGB light)',
+    pattern: /briefLabelClaude:"rgb\(255,153,51\)"/g,
+    replacer: () => 'briefLabelClaude:"rgb(22,163,74)"',
+  },
+  {
+    name: 'Brief label claude color → green (ANSI)',
+    pattern: /briefLabelClaude:"ansi:redBright"/g,
+    replacer: () => 'briefLabelClaude:"ansi:greenBright"',
+  },
 
   // ── macOS Cmd+V 图片粘贴修复 ──
 


### PR DESCRIPTION
## Problem

The green theme patches in ClawGod only cover **RGB colors** and the `clawd_body` (logo) ANSI color. When running in terminals **without true color support** (`COLORTERM` unset, `xterm-256color`), Claude Code uses the **ANSI color palette**, and the key brand colors remain red/orange:

| Property | RGB patched? | ANSI patched? |
|----------|:-----------:|:-----------:|
| `clawd_body` (logo) | ✅ | ✅ |
| `claude` (main brand) | ✅ | ❌ missing |
| `claudeShimmer` | ✅ | ❌ missing |
| `briefLabelClaude` | ❌ missing | ❌ missing |

## Root Cause

The patcher has:
- Logo + brand color → green (ANSI): only patches `clawd_body:"ansi:redBright"`
- But **does not** patch `claude:"ansi:redBright"`, `claudeShimmer:"ansi:yellowBright"`, or `briefLabelClaude`

On 256-color terminals (most Linux terminals, tmux, screen, etc.), the ANSI theme is used, so the main interface still shows red/orange instead of green.

## Fix

Added 5 new patches covering the missing ANSI + RGB variants:

| New patch | Target |
|-----------|--------|
| Theme claude color → green (ANSI) | `claude:"ansi:redBright"` → `"ansi:greenBright"` |
| Shimmer → green (ANSI) | `claudeShimmer:"ansi:yellowBright"` → `"ansi:greenBright"` |
| Brief label claude → green (RGB dark) | `briefLabelClaude:"rgb(215,119,87)"` → `"rgb(34,197,94)"` |
| Brief label claude → green (RGB light) | `briefLabelClaude:"rgb(255,153,51)"` → `"rgb(22,163,74)"` |
| Brief label claude → green (ANSI) | `briefLabelClaude:"ansi:redBright"` → `"ansi:greenBright"` |

## Testing

- Environment: Linux, `xterm-256color`, `COLORTERM` unset
- ClawGod v1.7.4 with Claude Code v2.1.218
- Verified: all `claude:`, `clawd_body:`, `briefLabelClaude:`, `claudeShimmer:` properties now resolve to green
- No impact on users with true color terminals (RGB patches were already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
