### PR TITLE
fix: expose Claude identity to Herdr

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2063,6 +2063,7 @@ if [ ! -x \"\$BUN_BIN\" ]; then
   exit 127
 fi
 export CLAUDE_CODE_EXECPATH=\"$CLAUDE_BIN.orig\"
+export HERDR_AGENT=\"\${HERDR_AGENT:-claude}\"
 exec \"\$BUN_BIN\" \"\$CLAWGOD_CLI\" \"\$@\""
 
 


### PR DESCRIPTION
ClawGod launches Claude Code through Bun:

bun ~/.clawgod/cli.cjs

This hides the claude foreground process from Herdr. Although the Claude integration hook still reports the native session ID, Herdr cannot identify the pane as Claude and leaves agent_status as unknown.

This change adds the following hint to the generated launcher:

export HERDR_AGENT="${HERDR_AGENT:-claude}"

This allows Herdr to correctly identify ClawGod-wrapped Claude sessions while still preserving an explicitly provided HERDR_AGENT value.

The change has no effect when ClawGod is used outside Herdr.