### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,4 +184,4 @@ GPL-3.0 — Not affiliated with Anthropic. Use at your own risk.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=0Chencc/clawgod&type=date&legend=top-left)](https://www.star-history.com/?repos=0Chencc%2Fclawgod&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=0Chencc/clawgod&type=date&legend=top-left)](https://star-history.dera.page/#0Chencc/clawgod&type=date&legend=top-left)

--- a/README_JP.md
+++ b/README_JP.md
@@ -184,4 +184,4 @@ GPL-3.0 — Anthropic とは無関係です。自己責任でご使用くださ�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=0Chencc/clawgod&type=date&legend=top-left)](https://www.star-history.com/?repos=0Chencc%2Fclawgod&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=0Chencc/clawgod&type=date&legend=top-left)](https://star-history.dera.page/#0Chencc/clawgod&type=date&legend=top-left)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -184,4 +184,4 @@ GPL-3.0 — 与 Anthropic 无关，风险自负。
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=0Chencc/clawgod&type=date&legend=top-left)](https://www.star-history.com/?repos=0Chencc%2Fclawgod&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=0Chencc/clawgod&type=date&legend=top-left)](https://star-history.dera.page/#0Chencc/clawgod&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart is currently broken because it relies on the old star-history service, which is no longer working due to GitHub stargazer API restrictions. This switches the chart image and its wrapping link to star-history.dera.page so the chart renders again in all three READMEs.