### PR TITLE
fix(windows): support irm pipe execution

### DIFF
--- a/.github/workflows/compat-daily.yml
+++ b/.github/workflows/compat-daily.yml
@@ -381,27 +381,36 @@ jobs:
         run: node build.js --check
 
       - name: Verify Windows installer encoding
-        # Windows PowerShell 5.1 uses the active ANSI code page for UTF-8 files
-        # without a BOM. Keep the BOM so non-ASCII patcher source survives both
-        # direct execution and the documented `irm ... | iex` install path.
+        # The documented `irm ... | iex` path passes a decoded string to the
+        # parser. A BOM then becomes a literal U+FEFF before #Requires. ASCII
+        # also avoids the Windows PowerShell 5.1 active-code-page fallback.
         shell: powershell
         run: |
           $bytes = [System.IO.File]::ReadAllBytes("$env:GITHUB_WORKSPACE\install.ps1")
-          $hasUtf8Bom = $bytes.Length -ge 3 -and
-            $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
-          if (-not $hasUtf8Bom) {
-            Write-Error 'install.ps1 must be UTF-8 with BOM for Windows PowerShell 5.1'
+          $nonAscii = $bytes | Where-Object { $_ -gt 0x7F } | Select-Object -First 1
+          if ($null -ne $nonAscii) {
+            Write-Error 'install.ps1 must be BOM-free ASCII for Windows PowerShell 5.1 and irm | iex'
+          }
+          $content = [System.Text.Encoding]::ASCII.GetString($bytes)
+          if (-not $content.StartsWith('#Requires')) {
+            Write-Error 'install.ps1 must start directly with #Requires'
           }
 
-      - name: Run install.ps1 (npm-fallback path)
-        # Use Windows PowerShell 5.1 to match the Win10 installation path.
+      - name: Run install.ps1 through Invoke-Expression (npm-fallback path)
+        # Use Windows PowerShell 5.1 and evaluate the installer as a decoded
+        # string, matching the documented `irm ... | iex` parser path.
         # Tee the complete output so a missing/failed patch run cannot be
         # mistaken for a successful install.
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           $log = Join-Path $env:RUNNER_TEMP 'install-windows.log'
-          & "$env:GITHUB_WORKSPACE\install.ps1" *>&1 |
+          $installerPath = "$env:GITHUB_WORKSPACE\install.ps1"
+          $installer = [System.IO.File]::ReadAllText(
+            $installerPath,
+            [System.Text.Encoding]::ASCII
+          )
+          Invoke-Expression $installer *>&1 |
             Tee-Object -FilePath $log
 
       - name: Verify install artifacts

--- a/build.js
+++ b/build.js
@@ -11,9 +11,17 @@ const { join } = require('node:path');
 const ROOT = __dirname;
 const SOURCE_ROOT = join(ROOT, 'src');
 const PLACEHOLDER_RE = /{{CLAWGOD:[^}]+}}/g;
-const UTF8_BOM = '\uFEFF';
 
 const identity = (content) => content;
+
+// Windows PowerShell 5.1 treats UTF-8 without a BOM as the active ANSI code
+// page, while `irm ... | iex` exposes a UTF-8 BOM as a literal U+FEFF token.
+// Keep the generated installer ASCII-only and encode Unicode in embedded
+// JavaScript/JSON as UTF-16 escape sequences, which both grammars understand.
+const escapeNonAscii = (content) => content.replace(
+  /[^\x00-\x7F]/g,
+  (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, '0')}`,
+);
 
 // PowerShell's single-quoted here-string cannot safely embed the annotated
 // proxy source used by install.sh. The existing Windows artifact intentionally
@@ -26,11 +34,14 @@ const compactProxyForPowerShell = (content) => content
   .filter((line) => !line.startsWith('// Allows Claude Code'))
   .join('\n');
 
+const compactAndEscapeProxyForPowerShell = (content) => escapeNonAscii(
+  compactProxyForPowerShell(content),
+);
+
 const TARGETS = [
   {
     name: 'install.sh',
     template: 'templates/install.sh',
-    bom: false,
     mode: 0o755,
     sources: {
       'extract-natives.mjs': ['shared/extract-natives.mjs', identity],
@@ -45,18 +56,18 @@ const TARGETS = [
   {
     name: 'install.ps1',
     template: 'templates/install.ps1',
-    bom: true,
+    asciiOnly: true,
     sources: {
-      'npm-fetch.mjs': ['windows/npm-fetch.mjs', identity],
-      'extract-natives.mjs': ['shared/extract-natives.mjs', identity],
-      'post-process.mjs': ['shared/post-process.mjs', identity],
-      'repatch.mjs': ['shared/repatch.mjs', identity],
-      'openai-proxy.cjs': ['shared/openai-proxy.cjs', compactProxyForPowerShell],
-      'cli.cjs': ['windows/cli.cjs', identity],
-      'patch.mjs': ['shared/patch.mjs', identity],
-      'features.json': ['shared/features.json', identity],
-      'lean-remove.cjs': ['windows/lean-remove.cjs', identity],
-      'lean-apply.cjs': ['windows/lean-apply.cjs', identity],
+      'npm-fetch.mjs': ['windows/npm-fetch.mjs', escapeNonAscii],
+      'extract-natives.mjs': ['shared/extract-natives.mjs', escapeNonAscii],
+      'post-process.mjs': ['shared/post-process.mjs', escapeNonAscii],
+      'repatch.mjs': ['shared/repatch.mjs', escapeNonAscii],
+      'openai-proxy.cjs': ['shared/openai-proxy.cjs', compactAndEscapeProxyForPowerShell],
+      'cli.cjs': ['windows/cli.cjs', escapeNonAscii],
+      'patch.mjs': ['shared/patch.mjs', escapeNonAscii],
+      'features.json': ['shared/features.json', escapeNonAscii],
+      'lean-remove.cjs': ['windows/lean-remove.cjs', escapeNonAscii],
+      'lean-apply.cjs': ['windows/lean-apply.cjs', escapeNonAscii],
     },
   },
 ];
@@ -90,7 +101,14 @@ function render(target) {
   if (unresolved) {
     throw new Error(`${target.template}: unresolved placeholders: ${[...new Set(unresolved)].join(', ')}`);
   }
-  return target.bom ? UTF8_BOM + output : output;
+  if (target.asciiOnly) {
+    const nonAsciiIndex = output.search(/[^\x00-\x7F]/);
+    if (nonAsciiIndex !== -1) {
+      const codePoint = output.codePointAt(nonAsciiIndex).toString(16).toUpperCase();
+      throw new Error(`${target.template}: non-ASCII U+${codePoint} at character ${nonAsciiIndex}`);
+    }
+  }
+  return output;
 }
 
 function firstDifference(actual, expected) {

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 5.1
+#Requires -Version 5.1
 <#
 .SYNOPSIS
     ClawGod Installer for Windows
@@ -34,10 +34,10 @@ $ClawDir = Join-Path $env:USERPROFILE ".clawgod"
 $BinDir  = Join-Path $env:USERPROFILE ".local\bin"
 $ClawSelfVersion = "0.0.0-dev"  # injected by release workflow from git tag
 
-# ─── Colors ───────────────────────────────────────────
+# --- Colors -----------------------------------------------------------
 
-function Write-OK($msg)   { Write-Host "  ✓ $msg" -ForegroundColor Green }
-function Write-Err($msg)  { Write-Host "  ✗ $msg" -ForegroundColor Red }
+function Write-OK($msg)   { Write-Host "  $([char]0x2713) $msg" -ForegroundColor Green }
+function Write-Err($msg)  { Write-Host "  $([char]0x2717) $msg" -ForegroundColor Red }
 function Write-Warn($msg) { Write-Host "  ! $msg" -ForegroundColor Yellow }
 function Write-Dim($msg)  { Write-Host "  $msg" -ForegroundColor DarkGray }
 
@@ -46,7 +46,7 @@ Write-Host "  ClawGod Installer" -ForegroundColor White -NoNewline
 Write-Host " (Windows)" -ForegroundColor DarkGray
 Write-Host ""
 
-# ─── Uninstall ────────────────────────────────────────
+# --- Uninstall --------------------------------------------------------
 
 if ($Uninstall) {
     # Restore original claude
@@ -84,7 +84,7 @@ if ($Uninstall) {
     exit 0
 }
 
-# ─── Prerequisites ────────────────────────────────────
+# --- Prerequisites ----------------------------------------------------
 
 try { $null = Get-Command node -ErrorAction Stop }
 catch {
@@ -98,7 +98,7 @@ if ($nodeVer -lt 18) {
     exit 1
 }
 
-# ─── Ensure Bun (runtime that executes the patched cli.js) ────────────
+# --- Ensure Bun (runtime that executes the patched cli.js) ------------
 
 $BunBin = $null
 try { $BunBin = (Get-Command bun -ErrorAction Stop).Source } catch {}
@@ -118,9 +118,9 @@ if (-not $BunBin) {
     }
 }
 
-# Resolve bun.ps1 → bun.exe. When Bun is installed via `npm install -g bun`,
+# Resolve bun.ps1 -> bun.exe. When Bun is installed via `npm install -g bun`,
 # Get-Command returns a .ps1 wrapper script. A .cmd launcher cannot invoke .ps1
-# directly — Windows opens the file association dialog instead of executing it.
+# directly -- Windows opens the file association dialog instead of executing it.
 # Probe known install paths instead of parsing wrapper scripts.
 if ($BunBin -and $BunBin -match '\.ps1$') {
     $resolved = $null
@@ -144,7 +144,7 @@ if ($BunBin -and $BunBin -match '\.ps1$') {
         if (Test-Path $chocoBin) { $resolved = $chocoBin }
     }
     if ($resolved) {
-        Write-Dim "Resolved bun.ps1 → $resolved"
+        Write-Dim "Resolved bun.ps1 -> $resolved"
         $BunBin = $resolved
     } else {
         Write-Warn "Bun resolved to .ps1 wrapper ($BunBin). The launcher may not work."
@@ -153,11 +153,11 @@ if ($BunBin -and $BunBin -match '\.ps1$') {
 }
 Write-OK "Bun: $(& $BunBin --version)"
 
-# ─── Bun version pre-flight ───────────────────────────────────────────
+# --- Bun version pre-flight -------------------------------------------
 # Anthropic builds the native binary with Bun's canary channel; stable
 # bun.sh trails by one version. Bun < 1.3.14 panics on cli.original.cjs
 # with "Expected CommonJS module to have a function wrapper". Refuse
-# early — no npm download / no patch / no late sanity surprise where
+# early -- no npm download / no patch / no late sanity surprise where
 # PowerShell's NativeCommandError display buries the friendly message.
 # Bump $MinBunVersion when Anthropic moves the embedded Bun forward
 # again.
@@ -197,8 +197,8 @@ if (-not $BunVersionOk) {
     exit 1
 }
 
-# ─── ripgrep prerequisite (search/grep tool) ──────────────────────────
-# Hard prerequisite — without rg the Grep tool inside Claude Code fails.
+# --- ripgrep prerequisite (search/grep tool) --------------------------
+# Hard prerequisite -- without rg the Grep tool inside Claude Code fails.
 
 try {
     $rgPath = (Get-Command rg -ErrorAction Stop).Source
@@ -216,7 +216,7 @@ catch {
     exit 1
 }
 
-# ─── Handle -NoUpgrade (skip download, re-patch only) ────────────────
+# --- Handle -NoUpgrade (skip download, re-patch only) -----------------
 if ($NoUpgrade) {
     New-Item -ItemType Directory -Force -Path $ClawDir | Out-Null
     New-Item -ItemType Directory -Force -Path $BinDir  | Out-Null
@@ -234,9 +234,9 @@ if ($NoUpgrade) {
     Write-OK "Skipping download (-NoUpgrade)"
 } else {
 
-# ─── Locate native Bun binary (cli.js source) ──────────────────────────
+# --- Locate native Bun binary (cli.js source) -------------------------
 # Source: npm registry (@anthropic-ai/claude-code-win32-<arch>).
-# Local binary detection is intentionally skipped — see policy note below.
+# Local binary detection is intentionally skipped -- see policy note below.
 
 New-Item -ItemType Directory -Force -Path $ClawDir | Out-Null
 New-Item -ItemType Directory -Force -Path $BinDir  | Out-Null
@@ -261,12 +261,12 @@ $platformSuffix = "win32-$arch"
 # out `claude update`, so users never re-run the underlying installers,
 # and those directories freeze at whatever version was on disk the day
 # clawgod was first installed. `claude update` (which is now redirected
-# here) would re-detect the frozen binary forever — never reaching the
+# here) would re-detect the frozen binary forever -- never reaching the
 # registry. See INCIDENT_LOG 2026-04-29 entry. The fix is to skip local
 # detection entirely; the npm tarball is ~60-90 MB compressed, fetched
 # once per upgrade.
 
-# npm registry — pull the platform tarball directly via Node.
+# npm registry -- pull the platform tarball directly via Node.
 #    Avoids depending on `npm` and `tar` being on PATH (older Windows 10
 #    builds lack tar.exe; some PowerShell shims mangle `& npm`). Node is
 #    already a hard prerequisite for the patcher, so reuse it.
@@ -280,7 +280,7 @@ if (-not $NativeBin) {
     $noProxy = $env:NO_PROXY
     if ($env:HTTPS_PROXY -or $env:HTTP_PROXY) {
         if ($noProxy -match '(?i)npmjs\.org') {
-            Write-Dim "NO_PROXY includes npmjs.org — using direct fetch"
+            Write-Dim "NO_PROXY includes npmjs.org -- using direct fetch"
         } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
             $useNpmFetch = $true
         } else {
@@ -424,8 +424,8 @@ $extractorPath = Join-Path $ClawDir "extract-natives.mjs"
  *
  * Parses the .bun (PE/ELF) or __BUN,__bun (Mach-O) section embedded in a
  * Bun standalone executable, walks the module graph, and extracts:
- *   - the entry-point module      → <out>/cli.original.js
- *   - every loader=napi module    → <out>/vendor/<name>/<arch>-<os>/<name>.node
+ *   - the entry-point module      \u2192 <out>/cli.original.js
+ *   - every loader=napi module    \u2192 <out>/vendor/<name>/<arch>-<os>/<name>.node
  *
  * Everything else is dropped (e.g. auto-generated *.js napi shims aren't
  * needed because cli.js already inlines the require('/$bunfs/root/X.node')
@@ -443,14 +443,14 @@ $extractorPath = Join-Path $ClawDir "extract-natives.mjs"
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
 
-// ─── Format constants ────────────────────────────────────────────────
+// \u2500\u2500\u2500 Format constants \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 const TRAILER             = Buffer.from('\n---- Bun! ----\n');
 const BUN_SECTION_NAME    = '.bun';
 const OFFSET_STRUCT_SIZE  = 32;
 const MODULE_RECORD_SIZE  = 52;
 
-// loader id → name (subset; only `napi` is acted on, rest informational)
+// loader id \u2192 name (subset; only `napi` is acted on, rest informational)
 const LOADERS = {
   0:'jsx', 1:'js', 2:'ts', 3:'tsx', 4:'css', 5:'file', 6:'json', 7:'jsonc',
   8:'toml', 9:'wasm', 10:'napi', 11:'base64', 12:'dataurl', 13:'text',
@@ -512,7 +512,7 @@ const PE_SECT_NAME_LEN      = 0x08;
 const IMAGE_MACHINE_AMD64   = 0x8664;
 const IMAGE_MACHINE_ARM64   = 0xaa64;
 
-// ─── Helpers ─────────────────────────────────────────────────────────
+// \u2500\u2500\u2500 Helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 function die(msg) { throw new Error(`error: ${msg}`); }
 
@@ -533,7 +533,7 @@ function decodeName(buf) {
   return buf.toString('utf8').replace(/\u0000+$/u, '');
 }
 
-// ─── Section locators (per format) ───────────────────────────────────
+// \u2500\u2500\u2500 Section locators (per format) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 function findSectionElf(buf) {
   if (buf.length < ELF_EHDR_SIZE) die('ELF too small');
@@ -662,7 +662,7 @@ function findBunSection(buf) {
   return findSectionPe(buf);
 }
 
-// ─── Payload + module records ────────────────────────────────────────
+// \u2500\u2500\u2500 Payload + module records \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 function parsePayload(sectionData) {
   if (sectionData.length < 8) die('.bun too small for length prefix');
@@ -711,7 +711,7 @@ function parseModules(payload, offsets) {
   return out;
 }
 
-// ─── Output dispatch ─────────────────────────────────────────────────
+// \u2500\u2500\u2500 Output dispatch \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 function napiBasename(name) {
   // Bun records may use either '/' (POSIX builds) or '\\' (PE) as separator;
@@ -721,7 +721,7 @@ function napiBasename(name) {
   return tail.replace(/\.node$/i, '');
 }
 
-// ─── Main ────────────────────────────────────────────────────────────
+// \u2500\u2500\u2500 Main \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 function main() {
   const [,, binaryPath, outputDir] = process.argv;
@@ -769,7 +769,7 @@ function main() {
     (entryText.includes('import{') || BUN_MOUNT_RE.test(entryText));
 
   // When chunked, also extract every non-napi module to a flat dir so the
-  // ESM graph resolves. We flatten <mount>/sub/path → sub__path and keep
+  // ESM graph resolves. We flatten <mount>/sub/path \u2192 sub__path and keep
   // napi under vendor/. We postpone path rewriting to post-process.mjs
   // (which knows the final install dir).
   const platDir = `${section.arch}-${section.os}`;
@@ -781,7 +781,7 @@ function main() {
     if (m.entry) {
       const out = join(outputDir, 'cli.original.js');
       writeFileSync(out, m.content);
-      console.log(`  cli.js   ${(m.content.length / 1024 / 1024).toFixed(2)} MB → ${out} (${m.name})`);
+      console.log(`  cli.js   ${(m.content.length / 1024 / 1024).toFixed(2)} MB \u2192 ${out} (${m.name})`);
       cliCount++;
     } else if (m.loader === 'napi') {
       const base = napiBasename(m.name);
@@ -790,7 +790,7 @@ function main() {
       mkdirSync(dir, { recursive: true });
       const out = join(dir, `${base}.node`);
       writeFileSync(out, m.content);
-      console.log(`  napi     ${(m.content.length / 1024).toFixed(0).padStart(5)} KB → ${out}`);
+      console.log(`  napi     ${(m.content.length / 1024).toFixed(0).padStart(5)} KB \u2192 ${out}`);
       napiCount++;
       napiNames.add(m.name.replaceAll('\\', '/'));
     } else if (isChunked && bunSub(m.name)) {
@@ -802,7 +802,7 @@ function main() {
       const flat = sub.replace(/\//g, '__');
       mkdirSync(graphDir, { recursive: true });
       writeFileSync(join(graphDir, flat), m.content);
-      console.log(`  chunk    ${(m.content.length / 1024).toFixed(0).padStart(6)} KB → bunfs/${flat}`);
+      console.log(`  chunk    ${(m.content.length / 1024).toFixed(0).padStart(6)} KB \u2192 bunfs/${flat}`);
       dropped++;  // count as dropped-from-entry (informational)
     } else {
       dropped++;
@@ -839,7 +839,7 @@ function main() {
 main();
 '@ | Set-Content $extractorPath -Encoding UTF8
 
-# ─── Extract cli.js + native modules from Bun binary ──────────
+# --- Extract cli.js + native modules from Bun binary ------------------
 
 # Single extractor pass: writes cli.original.js to $ClawDir and creates
 # vendor\<name>\<arch>-<os>\<name>.node for every napi module in one go.
@@ -861,9 +861,9 @@ if (-not (Test-Path $dstCli)) {
     exit 1
 }
 
-# Note: keep extractorPath around — repatch.mjs uses it on version drift
+# Note: keep extractorPath around -- repatch.mjs uses it on version drift
 
-# ─── Post-process cli.js for Bun runtime ──────────────────────
+# --- Post-process cli.js for Bun runtime -------------------------------
 
 Write-Dim "Rewriting bunfs paths and IIFE invocation ..."
 $postProc = Join-Path $ClawDir "post-process.mjs"
@@ -885,10 +885,10 @@ const isChunked = existsSync(pathMapFile);
 
 // (0) Strip leading @bun pragma comments (e.g. "// @bun @bytecode @bun-cjs\n")
 // Bun requires the file to start directly with "(function" (CJS) or the
-// first import (ESM) — any preceding comment breaks that detection.
+// first import (ESM) \u2014 any preceding comment breaks that detection.
 function stripPragma(c) { return c.replace(/^(?:\/\/[^\n]*\n)+/, ''); }
 
-// build-time fileURLToPath() leaks → use cli.cjs's own __filename
+// build-time fileURLToPath() leaks \u2192 use cli.cjs's own __filename
 function fixFileURLs(c) {
   return c.replace(
     /[\w$]+\.fileURLToPath\("file:\/\/\/home\/runner\/work\/claude-cli-internal\/claude-cli-internal\/[^"]*"\)/g,
@@ -897,9 +897,9 @@ function fixFileURLs(c) {
 }
 
 if (isChunked) {
-  // ── v2.1.245+ ESM chunk graph path ──
+  // \u2500\u2500 v2.1.245+ ESM chunk graph path \u2500\u2500
   const pathMap = JSON.parse(readFileSync(pathMapFile, 'utf8'));
-  // build the replace table: /$bunfs/root/X → <here>/<relative-on-disk>
+  // build the replace table: /$bunfs/root/X \u2192 <here>/<relative-on-disk>
   const replaceTable = new Map();
   for (const [bunPath, rel] of Object.entries(pathMap)) {
     replaceTable.set(bunPath, join(here, rel));
@@ -919,7 +919,7 @@ if (isChunked) {
     });
   }
 
-  // entry → cli.original.cjs (ESM, no IIFE wrap)
+  // entry \u2192 cli.original.cjs (ESM, no IIFE wrap)
   code = stripPragma(code);
   code = rewriteGraph(code);
   code = fixFileURLs(code);
@@ -941,10 +941,10 @@ if (isChunked) {
   }
   console.log(`cli.original.cjs: ${code.length} bytes (chunked, rewrote ${n} graph files)`);
 } else {
-  // ── Legacy single-bundle path ──
+  // \u2500\u2500 Legacy single-bundle path \u2500\u2500
   code = stripPragma(code);
 
-  // (1) bunfs .node module paths → runtime vendor lookup
+  // (1) bunfs .node module paths \u2192 runtime vendor lookup
   code = code.replace(
     /require\(['"](\/\$bunfs\/root\/([\w-]+)\.node)['"]\)/g,
     (m, _full, name) =>
@@ -970,7 +970,7 @@ if (-not (Test-Path (Join-Path $ClawDir "cli.original.cjs"))) {
 # Stamp source version so wrapper can detect drift on next launch
 Set-Content -Path (Join-Path $ClawDir ".source-version") -Value $NativeBinLabel -Encoding ASCII
 
-# If we pulled the binary from npm into a tmpdir, clean up — extraction
+# If we pulled the binary from npm into a tmpdir, clean up -- extraction
 # is done; drift detection only consults %USERPROFILE%\.local\share\claude\versions\.
 if ($NativeBinTmpDir -and (Test-Path $NativeBinTmpDir)) {
     Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
@@ -980,7 +980,7 @@ Write-OK "cli.original.cjs ready ($NativeBinLabel)"
 
 }  # end -NoUpgrade skip
 
-# ─── Write re-patch helper (used by wrapper on version drift) ─────────
+# --- Write re-patch helper (used by wrapper on version drift) ---------
 
 @'
 #!/usr/bin/env bun
@@ -1028,11 +1028,11 @@ console.log(`[clawgod] re-patched to ${basename(nativeBin)}`);
 '@ | Set-Content (Join-Path $ClawDir "repatch.mjs") -Encoding UTF8
 Write-OK "Re-patch helper installed (repatch.mjs)"
 
-# ─── Write OpenAI-compatible proxy ────────────────────────────
+# --- Write OpenAI-compatible proxy ------------------------------------
 
 # NOTE: PowerShell here-string @'...'@ cannot contain a line starting with '@
 # The proxy source is identical to the install.sh version.
-# $PSScriptRoot is empty when run via iex (e.g. claude update → iex(irm $url)).
+# $PSScriptRoot is empty when run via iex (e.g. claude update -> iex(irm $url)).
 # Join-Path "" "file" throws a terminating error that -ErrorAction cannot catch.
 try { $ProxySource = Get-Content (Join-Path $PSScriptRoot "openai-proxy.cjs") -Raw -ErrorAction Stop } catch { $ProxySource = $null }
 if (-not $ProxySource) {
@@ -1285,7 +1285,7 @@ module.exports = { startProxy: startProxy };
 $ProxySource | Set-Content (Join-Path $ClawDir "openai-proxy.cjs") -Encoding UTF8
 Write-OK "OpenAI-compatible proxy created (openai-proxy.cjs)"
 
-# ─── Write wrapper (cli.cjs, runs under Bun) ──────────────────
+# --- Write wrapper (cli.cjs, runs under Bun) --------------------------
 
 @'
 #!/usr/bin/env bun
@@ -1296,10 +1296,10 @@ const { spawnSync } = require('child_process');
 
 const clawgodDir = join(homedir(), '.clawgod');
 
-// Note: drift detection removed — see install.sh wrapper for full notes.
+// Note: drift detection removed \u2014 see install.sh wrapper for full notes.
 // `versions/` either doesn't exist (Windows) or doesn't grow on healthy
 // clawgod installs (we patch out `claude update`), so the check could only
-// retract a fresh install.ps1 / install.sh upgrade. `claude update` →
+// retract a fresh install.ps1 / install.sh upgrade. `claude update` \u2192
 // install.sh redirect is the single source of truth for version upgrades.
 
 // One-time migration: earlier wrapper versions set CLAUDE_CONFIG_DIR=~/.clawgod,
@@ -1385,7 +1385,7 @@ if (hasProviderApiKey) {
 // vLLM / etc.) don't share Anthropic's server-side handling of
 // x-anthropic-billing-header. That header carries a per-request `cch` field
 // which Anthropic's own server excludes from prompt-cache key calculation
-// (via cacheScope:null), but third-party proxies fold into the prefix hash —
+// (via cacheScope:null), but third-party proxies fold into the prefix hash \u2014
 // so the cached prefix changes every request and cache hit rate drops to
 // zero. Auto-disable the header whenever baseURL points away from Anthropic.
 // Users can force re-enable with CLAUDE_CODE_ATTRIBUTION_HEADER=1 if needed.
@@ -1420,7 +1420,7 @@ if (!process.env.CLAUDE_INTERNAL_FC_OVERRIDES && existsSync(featuresFile)) {
 }
 
 // Monkey-patch process.execPath: Anthropic's CLI uses process.execPath to
-// locate the native binary for shell wrappers (find→bfs, grep→ugrep, rg) and
+// locate the native binary for shell wrappers (find\u2192bfs, grep\u2192ugrep, rg) and
 // subprocess spawning. Under Bun, process.execPath returns the Bun runtime
 // path, not the Claude native binary. The launcher script sets
 // CLAUDE_CODE_EXECPATH to claude.orig (the real binary) before exec'ing
@@ -1433,7 +1433,7 @@ if (_realExecPath !== process.execPath) {
   });
 }
 
-// Lean mode toggle — --lean-off / --lean-on / --lean-max
+// Lean mode toggle \u2014 --lean-off / --lean-on / --lean-max
 if (process.argv.includes('--lean-off') || process.argv.includes('--lean-on') || process.argv.includes('--lean-max')) {
   const _leanOff = join(clawgodDir, '.lean-disabled');
   const _leanMax = join(clawgodDir, '.lean-max');
@@ -1484,7 +1484,7 @@ if (process.argv.includes('--lean-off') || process.argv.includes('--lean-on') ||
   process.exit(0);
 }
 
-// Update check — cached, non-blocking, 24h interval
+// Update check \u2014 cached, non-blocking, 24h interval
 try {
   const _ucFile = join(clawgodDir, '.update-check');
   const _verFile = join(clawgodDir, '.clawgod-version');
@@ -1494,7 +1494,7 @@ try {
     try { if (existsSync(_ucFile)) _uc = JSON.parse(readFileSync(_ucFile, 'utf8')); } catch {}
     var _semGt = function(a, b) { var x = a.split('.'), y = b.split('.'); for (var i = 0; i < 3; i++) { var d = (parseInt(x[i]||0)) - (parseInt(y[i]||0)); if (d) return d > 0; } return false; };
     if (_uc && _uc.v && _semGt(_uc.v, _localVer)) {
-      process.stderr.write('[clawgod] v' + _uc.v + ' available (installed: v' + _localVer + ") — run 'claude update' to upgrade\n");
+      process.stderr.write('[clawgod] v' + _uc.v + ' available (installed: v' + _localVer + ") \u2014 run 'claude update' to upgrade\n");
     }
     if (!_uc || Date.now() - (_uc.t || 0) > 86400000) {
       fetch('https://api.github.com/repos/0Chencc/clawgod/releases/latest', {
@@ -1513,13 +1513,13 @@ require('./cli.original.cjs');
 Set-Content (Join-Path $ClawDir ".clawgod-version") $ClawSelfVersion
 Write-OK "Wrapper created (cli.cjs)"
 
-# ─── Write universal patcher ──────────────────────────
-# (Same Node.js patcher as bash version — inline to avoid extra download)
+# --- Write universal patcher ------------------------------------------
+# (Same Node.js patcher as bash version -- inline to avoid extra download)
 
 $patcherCode = @'
 #!/usr/bin/env node
 /**
- * ClawGod Universal Patcher — 正则模式匹配, 跨版本兼容
+ * ClawGod Universal Patcher \u2014 \u6b63\u5219\u6a21\u5f0f\u5339\u914d, \u8de8\u7248\u672c\u517c\u5bb9
  */
 import { readFileSync, writeFileSync, existsSync, copyFileSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
@@ -1529,11 +1529,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const TARGET = join(__dirname, 'cli.original.cjs');
 const BACKUP = TARGET + '.bak';
 
-// ─── Regex-based patches (version-agnostic) ──────────────
+// \u2500\u2500\u2500 Regex-based patches (version-agnostic) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 const patches = [
   {
-    name: 'USER_TYPE → ant',
+    name: 'USER_TYPE \u2192 ant',
     pattern: /function ([\w$]+)\(\)\{return"external"\}/g,
     replacer: (m, fn) => `function ${fn}(){return"ant"}`,
     sentinel: 'return"external"',
@@ -1544,13 +1544,13 @@ const patches = [
     // (DLt), multitool dispatch (RS), and several other codepaths that need
     // to behave as if running the native binary. The property is frozen on
     // Bun 1.4+ (configurable:false, writable:false), so runtime monkey-patch
-    // is impossible — patch the source instead. See issue #133.
+    // is impossible \u2014 patch the source instead. See issue #133.
     //
     // v2.1.236+ wraps the guard in a typeof-Bun check:
-    //   function fv(){return Bun.isStandaloneExecutable===!0}        ≤v2.1.235
+    //   function fv(){return Bun.isStandaloneExecutable===!0}        \u2264v2.1.235
     //   function kw(){return typeof Bun<"u"&&Bun.isStandaloneExecutable===!0}  v2.1.236+
     // Match both via an optional `typeof Bun<"u"&&` prefix.
-    name: 'Bun.isStandaloneExecutable → true',
+    name: 'Bun.isStandaloneExecutable \u2192 true',
     pattern: /function ([\w$]+)\(\)\{return (?:typeof Bun<"u"&&)?Bun\.isStandaloneExecutable===!0\}/g,
     replacer: (m, fn) => `function ${fn}(){return!0}`,
   },
@@ -1565,7 +1565,7 @@ const patches = [
     // v2.1.245+ moved env-override parsing into a GrowthBook class method and
     // introduced a dead-code bug: the lazy parse short-circuits on the second
     // return, so features.json (CLAUDE_INTERNAL_FC_OVERRIDES) never reaches the
-    // feature store — tengu_prompt_cache_1h_config & friends silently lose effect.
+    // feature store \u2014 tengu_prompt_cache_1h_config & friends silently lose effect.
     //
     // v2.1.246 shape (chunk graph, _668.js):
     //   getEnvironmentOverrides(){if(this.environmentOverridesParsed)return this.environmentOverrides;return this.environmentOverridesParsed=!0,this.environmentOverrides;let e=this.deps.readEnvironmentOverrides();if(!e)return this.environmentOverrides;try{this.environmentOverrides=Ce(e),p(`GrowthBook: Using env var overrides for ${...}`)}catch{p(`GrowthBook: Failed to parse CLAUDE_INTERNAL_FC_OVERRIDES: ${e}`,...)}return this.environmentOverrides}
@@ -1628,8 +1628,8 @@ const patches = [
     sentinel: 'name:"ultraplan"',
   },
   {
-    // ≤v2.1.110: function X(){return Y("tengu_review_bughunter_config",null)?.enabled===!0}
-    // v2.1.119+: function X(){return Y("tengu_review_bughunter_config",null)} — bare getter
+    // \u2264v2.1.110: function X(){return Y("tengu_review_bughunter_config",null)?.enabled===!0}
+    // v2.1.119+: function X(){return Y("tengu_review_bughunter_config",null)} \u2014 bare getter
     // v2.1.152+: same bare-getter shape, config also feeds cost_note/duration_note/model
     // v2.1.214+: config key moved to a variable:
     //   var Yau="tengu_review_bughunter_config";
@@ -1668,16 +1668,16 @@ const patches = [
     //   Lookahead ensures we only strip the call inside the auto-mode gate
     //   (the next 300 chars must contain !=="firstParty") and not unrelated
     //   if(!fn(x))return!1; patterns elsewhere.
-    //   Not present in ≤v2.1.149 (provider gate was inline).
+    //   Not present in \u2264v2.1.149 (provider gate was inline).
     name: 'Auto-mode unlock for third-party API (provider helper gate)',
     pattern: /if\(!([\w$]+)\(([\w$]+)\)\)return!1;(?=(?:(?!function\s).){0,300}!=="firstParty")/g,
     replacer: () => '',
     optional: true,
   },
   {
-    // ≤v2.1.149: if(Y!=="firstParty"&&Y!=="anthropicAws")return!1;
-    // v2.1.158+: if(q!=="firstParty"&&q!=="anthropicAws"&&($==="claude-opus-4-6"||…))return!1;
-    // v2.1.214+: if(r!=="firstParty"&&!d6(r)&&(t==="claude-opus-4-6"||…))return!1;
+    // \u2264v2.1.149: if(Y!=="firstParty"&&Y!=="anthropicAws")return!1;
+    // v2.1.158+: if(q!=="firstParty"&&q!=="anthropicAws"&&($==="claude-opus-4-6"||\u2026))return!1;
+    // v2.1.214+: if(r!=="firstParty"&&!d6(r)&&(t==="claude-opus-4-6"||\u2026))return!1;
     //   "anthropicAws" replaced by helper function !fn(var).
     //   Match both: \1!=="anthropicAws" OR !fn(\1).
     name: 'Auto-mode unlock for third-party API (inline gate)',
@@ -1687,7 +1687,7 @@ const patches = [
   },
   {
     // CLI subcommand registered via commander chain:
-    //   .command("update").alias("upgrade").description("…").action(async()=>{…})
+    //   .command("update").alias("upgrade").description("\u2026").action(async()=>{\u2026})
     // The original action's update path is broken under clawgod: detectInstallType()
     // returns "unknown" because the launcher hides our cli.cjs from upstream's
     // path heuristics, and the unknown-fallback branch on macOS overwrites
@@ -1707,9 +1707,9 @@ const patches = [
     //
     // v2.1.232+ wraps the action handler in a framework helper. The helper
     // is a minified identifier whose name drifts across builds:
-    //   .action(async()=>{…})              ≤v2.1.231
-    //   .action(t(async(a)=>{…}))          v2.1.232 … v2.1.237
-    //   .action(n(async(u)=>{…}))          v2.1.238+
+    //   .action(async()=>{\u2026})              \u2264v2.1.231
+    //   .action(t(async(a)=>{\u2026}))          v2.1.232 \u2026 v2.1.237
+    //   .action(n(async(u)=>{\u2026}))          v2.1.238+
     // Match any one-letter minified helper via `identifier(` rather than
     // hardcoding a name, so a future rename keeps matching.
     name: "Redirect `claude update` to clawgod self-update",
@@ -1747,70 +1747,70 @@ const patches = [
     },
     sentinel: '.command("update").alias("upgrade")',
   },
-  // ── 绿色主题 (patch 标识) ──
+  // \u2500\u2500 \u7eff\u8272\u4e3b\u9898 (patch \u6807\u8bc6) \u2500\u2500
 
   {
-    name: 'Logo + brand color → green (RGB dark)',
+    name: 'Logo + brand color \u2192 green (RGB dark)',
     pattern: /clawd_body:"rgb\(215,119,87\)"/g,
     replacer: () => 'clawd_body:"rgb(34,197,94)"',
   },
   {
-    name: 'Logo + brand color → green (ANSI)',
+    name: 'Logo + brand color \u2192 green (ANSI)',
     pattern: /clawd_body:"ansi:redBright"/g,
     replacer: () => 'clawd_body:"ansi:greenBright"',
   },
   {
-    name: 'Theme claude color → green (dark)',
+    name: 'Theme claude color \u2192 green (dark)',
     pattern: /claude:"rgb\(215,119,87\)"/g,
     replacer: () => 'claude:"rgb(34,197,94)"',
   },
   {
-    name: 'Theme claude color → green (light)',
+    name: 'Theme claude color \u2192 green (light)',
     pattern: /claude:"rgb\(255,153,51\)"/g,
     replacer: () => 'claude:"rgb(22,163,74)"',
   },
   {
-    name: 'Shimmer → green',
+    name: 'Shimmer \u2192 green',
     pattern: /claudeShimmer:"rgb\(2[34]5,1[45]9,1[12]7\)"/g,
     replacer: () => 'claudeShimmer:"rgb(74,222,128)"',
   },
   {
-    name: 'Shimmer light → green',
+    name: 'Shimmer light \u2192 green',
     pattern: /claudeShimmer:"rgb\(255,183,101\)"/g,
     replacer: () => 'claudeShimmer:"rgb(34,197,94)"',
   },
   {
-    name: 'Hex brand color → green',
+    name: 'Hex brand color \u2192 green',
     pattern: /#da7756/g,
     replacer: () => '#22c55e',
   },
   {
-    name: 'Theme claude color → green (ANSI)',
+    name: 'Theme claude color \u2192 green (ANSI)',
     pattern: /claude:"ansi:redBright"/g,
     replacer: () => 'claude:"ansi:greenBright"',
   },
   {
-    name: 'Shimmer → green (ANSI)',
+    name: 'Shimmer \u2192 green (ANSI)',
     pattern: /claudeShimmer:"ansi:yellowBright"/g,
     replacer: () => 'claudeShimmer:"ansi:greenBright"',
   },
   {
-    name: 'Brief label claude color → green (RGB dark)',
+    name: 'Brief label claude color \u2192 green (RGB dark)',
     pattern: /briefLabelClaude:"rgb\(215,119,87\)"/g,
     replacer: () => 'briefLabelClaude:"rgb(34,197,94)"',
   },
   {
-    name: 'Brief label claude color → green (RGB light)',
+    name: 'Brief label claude color \u2192 green (RGB light)',
     pattern: /briefLabelClaude:"rgb\(255,153,51\)"/g,
     replacer: () => 'briefLabelClaude:"rgb(22,163,74)"',
   },
   {
-    name: 'Brief label claude color → green (ANSI)',
+    name: 'Brief label claude color \u2192 green (ANSI)',
     pattern: /briefLabelClaude:"ansi:redBright"/g,
     replacer: () => 'briefLabelClaude:"ansi:greenBright"',
   },
 
-  // ── macOS Cmd+V 图片粘贴修复 ──
+  // \u2500\u2500 macOS Cmd+V \u56fe\u7247\u7c98\u8d34\u4fee\u590d \u2500\u2500
 
   {
     // Under Bun runtime (clawgod), macOS Cmd+V pastes the image file path
@@ -1820,7 +1820,7 @@ const patches = [
     //
     // Fix: when all image path reads fail (L.length===0 && R.length>0)
     // and we're on macOS (d) with no other text (D.length===0), fall back
-    // to the clipboard image reader (m()) — same path that Ctrl+V uses.
+    // to the clipboard image reader (m()) \u2014 same path that Ctrl+V uses.
     //
     // Shape:
     //   if(L.length===0&&R.length>0)at("input_image_drag","read_failed"),D.push(...R)
@@ -1835,12 +1835,12 @@ const patches = [
     optional: true,
   },
 
-  // ── Glob/Grep 工具恢复 ──
+  // \u2500\u2500 Glob/Grep \u5de5\u5177\u6062\u590d \u2500\u2500
 
   {
     // Bun inlines EMBEDDED_SEARCH_TOOLS env as literal "true" at compile time.
-    // This makes bC() always return true → Wft() returns the shadow set
-    // containing "Glob" and "Grep" → those tools are hidden from the user.
+    // This makes bC() always return true \u2192 Wft() returns the shadow set
+    // containing "Glob" and "Grep" \u2192 those tools are hidden from the user.
     // Under clawgod (Bun runtime, not native binary) the env is unset, but
     // the code still says ct("true") instead of ct(process.env.EMBEDDED_SEARCH_TOOLS).
     //
@@ -1849,7 +1849,7 @@ const patches = [
     //     return process.env.CLAUDE_CODE_ENTRYPOINT!=="local-agent"}
     //
     // Patch: replace ct("true") with ct(process.env.EMBEDDED_SEARCH_TOOLS)
-    // so the guard reads the actual env var (unset → falsy → return false →
+    // so the guard reads the actual env var (unset \u2192 falsy \u2192 return false \u2192
     // Glob/Grep tools available).
     name: 'Restore Glob/Grep tools (un-inline EMBEDDED_SEARCH_TOOLS)',
     pattern: /function ([\w$]+)\(\)\{if\(!([\w$]+)\("true"\)\)return!1;if\([\w$]+\(\)\)return!1;return process\.env\.CLAUDE_CODE_ENTRYPOINT!=="local-agent"\}/g,
@@ -1859,7 +1859,7 @@ const patches = [
     optional: true,
   },
 
-  // ── 地区隐写中和 (v2.1.197+) ──
+  // \u2500\u2500 \u5730\u533a\u9690\u5199\u4e2d\u548c (v2.1.197+) \u2500\u2500
 
   {
     // v2.1.197+: geo-steganography in system prompt date string.
@@ -1886,9 +1886,9 @@ const patches = [
   },
   {
     // v2.1.197+: rdp() performs three-axis geo detection:
-    //   1. timezone === "Asia/Shanghai" || "Asia/Urumqi"  → cnTZ
-    //   2. ANTHROPIC_BASE_URL hostname in XOR-obfuscated domain blocklist → known
-    //   3. ANTHROPIC_BASE_URL contains CN-LLM vendor keywords → labKw
+    //   1. timezone === "Asia/Shanghai" || "Asia/Urumqi"  \u2192 cnTZ
+    //   2. ANTHROPIC_BASE_URL hostname in XOR-obfuscated domain blocklist \u2192 known
+    //   3. ANTHROPIC_BASE_URL contains CN-LLM vendor keywords \u2192 labKw
     //
     // Shape:
     //   function rdp(){if(vrt())return null;let e=ndp(),t=ekt(),
@@ -1907,19 +1907,19 @@ const patches = [
   {
     // v2.1.197+: odp(known, labKw) selects a Unicode apostrophe to encode
     // proxy detection state into the system prompt:
-    //   !known && !labKw → U+0027 (ASCII)
-    //   known  && !labKw → U+2019 (RIGHT SINGLE QUOTATION MARK)
-    //   !known && labKw  → U+02BC (MODIFIER LETTER APOSTROPHE)
-    //   known  && labKw  → U+02B9 (MODIFIER LETTER PRIME)
+    //   !known && !labKw \u2192 U+0027 (ASCII)
+    //   known  && !labKw \u2192 U+2019 (RIGHT SINGLE QUOTATION MARK)
+    //   !known && labKw  \u2192 U+02BC (MODIFIER LETTER APOSTROPHE)
+    //   known  && labKw  \u2192 U+02B9 (MODIFIER LETTER PRIME)
     //
     // Shape:
     //   function odp(e,t){if(!e&&!t)return"'";if(e&&!t)return"'";
-    //     if(!e&&t)return"ʼ";return"ʹ"}
+    //     if(!e&&t)return"\u02bc";return"\u02b9"}
     //
     // Patch: always return ASCII apostrophe regardless of detection state.
     // The return values may appear as \uXXXX escapes or literal UTF-8 in
     // the bundle depending on bundler version. Match both forms.
-    // Defense-in-depth — qla patch above already bypasses the call to odp,
+    // Defense-in-depth \u2014 qla patch above already bypasses the call to odp,
     // but if qla's shape changes this keeps odp harmless.
     name: 'Neutralize apostrophe steganography (odp)',
     pattern: new RegExp(
@@ -1934,10 +1934,10 @@ const patches = [
       const fn = m.match(/^function ([\w$]+)/)[1];
       return `function ${fn}(e,t){return"'"}`;
     },
-    optional: true,  // defense-in-depth; rdp→null already neutralizes the stego channel
+    optional: true,  // defense-in-depth; rdp\u2192null already neutralizes the stego channel
   },
 
-  // ── 限制移除 ──
+  // \u2500\u2500 \u9650\u5236\u79fb\u9664 \u2500\u2500
 
   {
     name: 'Remove CYBER_RISK_INSTRUCTION',
@@ -1966,11 +1966,11 @@ const patches = [
     optional: true,
   },
 
-  // ── 消息过滤 ──
+  // \u2500\u2500 \u6d88\u606f\u8fc7\u6ee4 \u2500\u2500
 
   {
     // v2.1.88-~v2.1.91: fn()!=="ant"){if(q.attachment.type==="hook_additional_context"...
-    // v2.1.92+        : fn()!=="ant"&&paY.has(q.attachment.type) — paY is an empty Set
+    // v2.1.92+        : fn()!=="ant"&&paY.has(q.attachment.type) \u2014 paY is an empty Set
     //                    in v2.1.110, so this filter is effectively a no-op; patch anyway
     //                    to guard against paY being populated in future versions.
     name: 'Attachment filter bypass',
@@ -1979,7 +1979,7 @@ const patches = [
     optional: true,  // filter may be removed entirely in future versions
   },
   {
-    // Legacy (≤v2.1.91) ternary form: fn()!=="ant"?tRY(_,sRY(K)):K
+    // Legacy (\u2264v2.1.91) ternary form: fn()!=="ant"?tRY(_,sRY(K)):K
     name: 'Message list filter bypass (legacy ternary)',
     pattern: /([\w$]+)\(\)!=="ant"\?([\w$]+)\(([\w$]+),([\w$]+)\(([\w$]+)\)\):([\w$]+)/g,
     replacer: (m, fn, tRY, underscore, sRY, K, fallback) => fallback,
@@ -1997,7 +1997,7 @@ const patches = [
     // Shell-integration generator (iT6 in v2.1.140, was Wa1 in older versions)
     // emits a zsh/bash function that calls the native claude binary with
     // ARGV0=ugrep|rg|... for multitool dispatch. After clawgod installs, the
-    // baked path points at our shell-script launcher — but shell scripts
+    // baked path points at our shell-script launcher \u2014 but shell scripts
     // CANNOT preserve argv[0] (kernel shebang re-exec overwrites it, and zsh
     // additionally refuses to export ARGV0 as env). The shell function then
     // fails because bun receives e.g. -G and errors with "Invalid Argument".
@@ -2007,14 +2007,14 @@ const patches = [
     // a real binary that honors argv[0]. See issue #82.
     //
     // Generator shape across versions:
-    //   v2.1.88 (Wa1):  let Y=E4([_]),...  ← _ is the claude binary path, no in-function compute
+    //   v2.1.88 (Wa1):  let Y=E4([_]),...  \u2190 _ is the claude binary path, no in-function compute
     //   v2.1.140 (iT6): let ...,z=FJ$.join(Le(),A?"claude.exe":"claude"),Y=A?rL(z):z,...
-    //                   ← path computed inside via join(versionsDir, "claude[.exe]")
-    // Anchor on the join(...) ternary form unique to the generator — the
+    //                   \u2190 path computed inside via join(versionsDir, "claude[.exe]")
+    // Anchor on the join(...) ternary form unique to the generator \u2014 the
     // bare "claude.exe":"claude" string also appears in u18() (basename
     // helper) but never inside a path.join(), so this regex hits exactly the
     // shell-integration generator and nothing else.
-    name: 'Shell integration → claude.orig (multitool dispatch fix)',
+    name: 'Shell integration \u2192 claude.orig (multitool dispatch fix)',
     pattern: /([\w$]+\.join\([\w$]+\(\),[\w$]+\?)"claude\.exe":"claude"(\))/g,
     replacer: (m, prefix, suffix) => `${prefix}"claude.orig.exe":"claude.orig"${suffix}`,
     sentinel: '?"claude.exe":"claude")',
@@ -2022,7 +2022,7 @@ const patches = [
   },
 ];
 
-// ─── Main ─────────────────────────────────────────────────
+// \u2500\u2500\u2500 Main \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 // cli.original path (legacy single-bundle) or graph dir (v2.1.245+)
 const args = process.argv.slice(2);
@@ -2035,19 +2035,19 @@ const isGraph = existsSync(GRAPH_DIR);
 
 if (revert) {
   if (isGraph) {
-    // graph: restore each file from its .bak (no-op if none) — full graph
+    // graph: restore each file from its .bak (no-op if none) \u2014 full graph
     // backup isn't taken for chunks; only the entry has a .bak. Re-extract
     // instead: the safest revert for graph installs is to rerun extract.
-    console.log('⚠️  Graph install detected — run install.sh to re-extract clean source.');
+    console.log('\u26a0\ufe0f  Graph install detected \u2014 run install.sh to re-extract clean source.');
     process.exit(0);
   }
-  if (!existsSync(BACKUP)) { console.error('❌ No backup found'); process.exit(1); }
+  if (!existsSync(BACKUP)) { console.error('\u274c No backup found'); process.exit(1); }
   copyFileSync(BACKUP, TARGET);
-  console.log('✅ Reverted from backup');
+  console.log('\u2705 Reverted from backup');
   process.exit(0);
 }
 
-// ── Load target(s) ─────────────────────────────
+// \u2500\u2500 Load target(s) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 // isGraph: files = { 'cli.original.cjs': '...', 'bunfs/_444.js': '...', ... }
 // else:    files = { 'cli.original.cjs': '...' }
 let files = {};
@@ -2059,7 +2059,7 @@ if (isGraph) {
   }
 } else {
   if (!existsSync(TARGET)) {
-    console.error('❌ Target not found:', TARGET);
+    console.error('\u274c Target not found:', TARGET);
     process.exit(1);
   }
   files[TARGET] = readFileSync(TARGET, 'utf8');
@@ -2069,11 +2069,11 @@ if (isGraph) {
 const version = (files[TARGET] || '').match(/Version:\s*([\d.]+)/)?.[1] || 'unknown';
 const isCJSBundle = !isGraph; // legacy
 
-console.log(`\n${'═'.repeat(55)}`);
+console.log(`\n${'\u2550'.repeat(55)}`);
 console.log(`  ClawGod (universal)`);
 console.log(`  Target: cli.original.cjs (v${version}) ${isGraph ? `[graph: ${Object.keys(files).length} files]` : ''}`);
 console.log(`  Mode: ${dryRun ? 'DRY RUN' : verify ? 'VERIFY' : 'APPLY'}`);
-console.log(`${'═'.repeat(55)}\n`);
+console.log(`${'\u2550'.repeat(55)}\n`);
 
 // unified search: gather all matches of a pattern across every loaded file.
 // validate() receives the full file text so surrounding-context patterns keep working.
@@ -2083,7 +2083,7 @@ function collectMatches(p) {
     const matches = [...content.matchAll(p.pattern)];
     if (matches.length === 0) continue;
     let rel = matches;
-    // per-file validate / selectIndex — but these were designed for a single
+    // per-file validate / selectIndex \u2014 but these were designed for a single
     // bundle string. For graph, the pattern is applied per file, so each file
     // is an independent unit. validate() sees that file's content.
     if (p.validate) rel = matches.filter((m) => p.validate(m[0], content));
@@ -2111,13 +2111,13 @@ for (const p of patches) {
   // unique: if the aggregated count is >1 *across files* but the pattern
   // should hit exactly once in the whole app, we only allow applying to a
   // single file. Legacy enforced uniqueness over the whole bundle string;
-  // graph splits it per-file so each file normally has ≤1 match anyway.
+  // graph splits it per-file so each file normally has \u22641 match anyway.
   let totalMatches = 0;
   for (const fm of fileMatches) totalMatches += fm.matches.length;
 
   if (relevantFiles.length === 0) {
     if (p.optional) {
-      console.log(`  ⏭  ${p.name} (not present in this version)`);
+      console.log(`  \u23ed  ${p.name} (not present in this version)`);
       skipped++;
       continue;
     }
@@ -2125,21 +2125,21 @@ for (const p of patches) {
       const sentinels = Array.isArray(p.sentinel) ? p.sentinel : [p.sentinel];
       const stillPresent = sentinels.filter((s) => Object.values(files).some((c) => c.includes(s)));
       if (stillPresent.length > 0) {
-        console.log(`  ❌ ${p.name} — regex stale, sentinel still in source: ${stillPresent.map((s) => JSON.stringify(s)).join(', ')}`);
+        console.log(`  \u274c ${p.name} \u2014 regex stale, sentinel still in source: ${stillPresent.map((s) => JSON.stringify(s)).join(', ')}`);
         failed++;
         continue;
       }
-      console.log(`  ✅ ${p.name} (already applied, sentinel absent)`);
+      console.log(`  \u2705 ${p.name} (already applied, sentinel absent)`);
       applied++;
       continue;
     }
-    console.log(`  ⚠️  ${p.name} (0 matches, no sentinel — cannot verify)`);
+    console.log(`  \u26a0\ufe0f  ${p.name} (0 matches, no sentinel \u2014 cannot verify)`);
     skipped++;
     continue;
   }
 
   if (verify) {
-    console.log(`  ⬚  ${p.name} — ${totalMatches} match(es), not yet applied`);
+    console.log(`  \u2b1a  ${p.name} \u2014 ${totalMatches} match(es), not yet applied`);
     skipped++;
     continue;
   }
@@ -2171,37 +2171,37 @@ for (const p of patches) {
   }
 
   if (fileChangedCount > 0) {
-    console.log(`  ✅ ${p.name} (${fileChangedCount} replacement${fileChangedCount > 1 ? 's' : ''} in ${appliedFiles} file${appliedFiles > 1 ? 's' : ''})`);
+    console.log(`  \u2705 ${p.name} (${fileChangedCount} replacement${fileChangedCount > 1 ? 's' : ''} in ${appliedFiles} file${appliedFiles > 1 ? 's' : ''})`);
     applied++;
   } else if (relevantFiles.length > 0) {
-    console.log(`  ⏭  ${p.name} (no change needed)`);
+    console.log(`  \u23ed  ${p.name} (no change needed)`);
     skipped++;
   }
 }
 
-console.log(`\n${'─'.repeat(55)}`);
+console.log(`\n${'\u2500'.repeat(55)}`);
 console.log(`  Result: ${applied} applied, ${skipped} skipped, ${failed} failed`);
 
 if (!dryRun && !verify && applied > 0) {
   // backup the entry (legacy semantics); graph writes all files in place
   if (!existsSync(BACKUP)) {
     copyFileSync(TARGET, BACKUP);
-    console.log(`  📦 Backup: ${BACKUP}`);
+    console.log(`  \ud83d\udce6 Backup: ${BACKUP}`);
   }
   for (const [fname, content] of Object.entries(files)) {
     writeFileSync(fname, content, 'utf8');
   }
   const origSize = isGraph ? 0 : (readFileSync(BACKUP, 'utf8').length || 0);
-  console.log(`  📝 Written: ${Object.keys(files).length} file(s) ${isGraph ? '(graph)' : ''}`);
+  console.log(`  \ud83d\udcdd Written: ${Object.keys(files).length} file(s) ${isGraph ? '(graph)' : ''}`);
 }
 
-console.log(`${'═'.repeat(55)}\n`);
+console.log(`${'\u2550'.repeat(55)}\n`);
 '@
 
 Set-Content (Join-Path $ClawDir "patch.mjs") $patcherCode -Encoding UTF8
 Write-OK "Patcher created (patch.mjs)"
 
-# ─── Apply patches ────────────────────────────────────
+# --- Apply patches ----------------------------------------------------
 
 Write-Dim "Applying patches ..."
 node (Join-Path $ClawDir "patch.mjs")
@@ -2210,7 +2210,7 @@ if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-# ─── Create default configs ───────────────────────────
+# --- Create default configs -------------------------------------------
 
 $featuresFile = Join-Path $ClawDir "features.json"
 if (-not (Test-Path $featuresFile)) {
@@ -2233,7 +2233,7 @@ if (-not (Test-Path $featuresFile)) {
     Write-OK "Default features.json created"
 }
 
-# ─── Lean mode: optimize ~/.claude/settings.json ─────
+# --- Lean mode: optimize ~/.claude/settings.json ----------------------
 $leanOffFlag = Join-Path $ClawDir ".lean-disabled"
 $leanMaxFlag = Join-Path $ClawDir ".lean-max"
 $claudeSettingsDir = Join-Path $env:USERPROFILE ".claude"
@@ -2295,11 +2295,11 @@ if (changed) fs.writeFileSync(settingsPath, JSON.stringify(s, null, 2) + "\n");
     Write-Host "  $([char]0x2022) Lean mode disabled (claude --lean-on to re-enable)" -ForegroundColor DarkGray
 }
 
-# ─── Sanity check: ensure user's Bun can actually load cli.original.cjs ──
+# --- Sanity check: ensure user's Bun can load cli.original.cjs --------
 # Anthropic builds the native binary with a bleeding-edge Bun build (e.g.
 # 1.3.14 while stable still ships 1.3.13). Older Bun crashes loading the
 # extracted cli.original.cjs with "Expected CommonJS module to have a
-# function wrapper". Detect this BEFORE we install the launcher — better
+# function wrapper". Detect this BEFORE we install the launcher -- better
 # to fail loudly than to leave the user with a launcher that panics on
 # first invocation.
 
@@ -2310,7 +2310,7 @@ $sanityCli = Join-Path $ClawDir "cli.cjs"
 # this script is piped through `iex`) that terminates BEFORE we even
 # read $sanityOut. Localize ErrorActionPreference + try/catch so the
 # panic message reliably lands in $sanityOut and our friendly Write-Err
-# block runs. Defense-in-depth — pre-flight already blocks Bun < $MinBunVersion;
+# block runs. Defense-in-depth -- pre-flight already blocks Bun < $MinBunVersion;
 # this remains for the day Anthropic bumps embedded Bun past our constant.
 $sanityOut = $null
 try {
@@ -2330,7 +2330,7 @@ if ($sanityOut -match "Expected CommonJS module to have a function wrapper") {
     Write-Err ""
     Write-Err "  Anthropic builds with Bun's canary channel (currently ~1.3.14), while"
     Write-Err "  bun.sh's main download is on stable (currently 1.3.13). The canary build"
-    Write-Err "  is NOT visible on bun.sh's download page — it lives on GitHub Releases"
+    Write-Err "  is NOT visible on bun.sh's download page -- it lives on GitHub Releases"
     Write-Err "  and is reachable only via 'bun upgrade --canary'."
     Write-Err ""
     Write-Err "  If your bun is from bun.sh:"
@@ -2343,7 +2343,7 @@ if ($sanityOut -match "Expected CommonJS module to have a function wrapper") {
     Write-Err "    irm https://bun.sh/install.ps1 | iex"
     Write-Err "    bun upgrade --canary"
     Write-Err ""
-    Write-Err "  Then re-run .\install.ps1 — this sanity check will pass."
+    Write-Err "  Then re-run .\install.ps1 -- this sanity check will pass."
     exit 1
 }
 if ($sanityExitCode -ne 0) {
@@ -2354,7 +2354,7 @@ if ($sanityExitCode -ne 0) {
 }
 Write-OK "Bun loads cli.original.cjs"
 
-# ─── Replace claude command ───────────────────────────
+# --- Replace claude command -------------------------------------------
 
 # Build launcher content using %USERPROFILE% env var where possible to avoid
 # encoding issues when the profile path contains non-ASCII characters (e.g.
@@ -2369,7 +2369,7 @@ if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::Ordinal
     $bunRelative = $normalizedBunBin.Substring($normalizedUserProfile.Length).TrimStart('\', '/')
     $bunPathInCmd = "%USERPROFILE%\$bunRelative"
 } else {
-    # Bun outside USERPROFILE (e.g. system-wide install) — fall back to
+    # Bun outside USERPROFILE (e.g. system-wide install) -- fall back to
     # absolute path since %USERPROFILE%-relative expansion doesn't apply.
     $bunPathInCmd = $BunBin
 }
@@ -2406,13 +2406,13 @@ foreach ($loc in @(
         # Back up .exe if exists and not already backed up
         if ($loc -like "*.exe" -and -not (Test-Path $claudeOrigExe)) {
             Copy-Item $loc $claudeOrigExe -Force
-            Write-OK "Original claude.exe backed up → claude.orig.exe"
+            Write-OK "Original claude.exe backed up -> claude.orig.exe"
             $originalFound = $true
         }
         # Back up .cmd if exists and not already backed up
         if ($loc -like "*.cmd" -and -not (Test-Path $claudeOrigCmd)) {
             Copy-Item $loc $claudeOrigCmd -Force
-            Write-OK "Original claude.cmd backed up → claude.orig.cmd"
+            Write-OK "Original claude.cmd backed up -> claude.orig.cmd"
             $originalFound = $true
         }
         # If it's a versions directory, find the latest exe
@@ -2420,7 +2420,7 @@ foreach ($loc in @(
             $latestExe = Get-ChildItem $loc -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
             if ($latestExe -and -not (Test-Path $claudeOrigExe)) {
                 Copy-Item $latestExe.FullName $claudeOrigExe -Force
-                Write-OK "Original claude backed up → claude.orig.exe ($($latestExe.Name))"
+                Write-OK "Original claude backed up -> claude.orig.exe ($($latestExe.Name))"
                 $originalFound = $true
             }
         }
@@ -2438,13 +2438,13 @@ Get-ChildItem $BinDir -Filter "claude.*.exe" -ErrorAction SilentlyContinue |
 if (Test-Path $claudeExe) {
     if (-not (Test-Path $claudeOrigExe)) {
         Rename-Item $claudeExe $claudeOrigExe -Force
-        Write-OK "Renamed claude.exe → claude.orig.exe"
+        Write-OK "Renamed claude.exe -> claude.orig.exe"
     } else {
-        # Backup already exists — just remove the new claude.exe
+        # Backup already exists -- just remove the new claude.exe
         try {
             Remove-Item -Force $claudeExe
         } catch {
-            # File locked (running process) — rename aside with timestamp
+            # File locked (running process) -- rename aside with timestamp
             $ts = Get-Date -Format "yyyyMMddHHmmss"
             Rename-Item $claudeExe "claude.$ts.exe" -Force -ErrorAction SilentlyContinue
         }
@@ -2462,9 +2462,9 @@ if (Test-Path $claudeExe) {
 foreach ($cmd in @("claude", "clawgod")) {
     $launcherContent | Set-Content (Join-Path $BinDir "$cmd.cmd") -Encoding Default
 }
-Write-OK "Commands 'claude' + 'clawgod' → patched"
+Write-OK "Commands 'claude' + 'clawgod' -> patched"
 
-# ─── Ensure BinDir is in PATH ─────────────────────────
+# --- Ensure BinDir is in PATH -----------------------------------------
 
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($userPath -notlike "*$BinDir*") {
@@ -2474,16 +2474,16 @@ if ($userPath -notlike "*$BinDir*") {
     Write-Dim "(restart terminal for PATH to take effect)"
 }
 
-# ─── Done ─────────────────────────────────────────────
+# --- Done -------------------------------------------------------------
 
 Write-Host ""
 Write-Host "  ClawGod installed!" -ForegroundColor Green
 Write-Host ""
-Write-Dim "  claude            — Start patched Claude Code (green logo)"
-Write-Dim "  claude.orig       — Run original unpatched Claude Code"
+Write-Dim "  claude            -- Start patched Claude Code (green logo)"
+Write-Dim "  claude.orig       -- Run original unpatched Claude Code"
 Write-Host ""
 Write-Dim "  Updates: 'claude update' is patched to route through this installer."
-Write-Dim "  Just run it as usual — pulls latest Anthropic release + re-patches"
+Write-Dim "  Just run it as usual -- pulls latest Anthropic release + re-patches"
 Write-Dim "  in one step. Extra options:"
 Write-Dim "    claude update --version 2.1.180   (install a specific version)"
 Write-Dim "    claude update --no-upgrade        (re-patch without downloading)"
@@ -2498,6 +2498,6 @@ Write-Host ""
 Write-Dim "  If 'claude' panics with 'Expected CommonJS module to have a function wrapper',"
 Write-Dim "  your Bun lags Anthropic's embedded Bun. Upgrade with one of:"
 Write-Dim "    bun upgrade --canary           (if installed from bun.sh)"
-Write-Dim "    scoop update bun               (scoop — may lag stable)"
+Write-Dim "    scoop update bun               (scoop -- may lag stable)"
 Write-Dim "    irm https://bun.sh/install.ps1 | iex   (re-install latest)"
 Write-Host ""

--- a/src/README.md
+++ b/src/README.md
@@ -19,9 +19,10 @@ when either generated installer is missing or differs from its sources.
 - `templates/` contain the shell around those payloads and use
   `{{CLAWGOD:<installed-name>}}` placeholders.
 
-The PowerShell template intentionally has no byte-order mark. `build.js` owns
-output encoding and always adds the UTF-8 BOM required by Windows PowerShell
-5.1 to the generated `install.ps1`.
+The PowerShell template and generated installer are intentionally BOM-free and
+ASCII-only. This keeps both direct Windows PowerShell 5.1 execution and the
+documented `irm ... | iex` path independent of the machine's active code page.
+`build.js` escapes Unicode in embedded JavaScript/JSON payloads as `\uXXXX`.
 
 Do not edit the generated installers directly. If an emergency fix starts in a
 generated file, port it to the corresponding source/template immediately and

--- a/src/templates/install.ps1
+++ b/src/templates/install.ps1
@@ -34,10 +34,10 @@ $ClawDir = Join-Path $env:USERPROFILE ".clawgod"
 $BinDir  = Join-Path $env:USERPROFILE ".local\bin"
 $ClawSelfVersion = "0.0.0-dev"  # injected by release workflow from git tag
 
-# ─── Colors ───────────────────────────────────────────
+# --- Colors -----------------------------------------------------------
 
-function Write-OK($msg)   { Write-Host "  ✓ $msg" -ForegroundColor Green }
-function Write-Err($msg)  { Write-Host "  ✗ $msg" -ForegroundColor Red }
+function Write-OK($msg)   { Write-Host "  $([char]0x2713) $msg" -ForegroundColor Green }
+function Write-Err($msg)  { Write-Host "  $([char]0x2717) $msg" -ForegroundColor Red }
 function Write-Warn($msg) { Write-Host "  ! $msg" -ForegroundColor Yellow }
 function Write-Dim($msg)  { Write-Host "  $msg" -ForegroundColor DarkGray }
 
@@ -46,7 +46,7 @@ Write-Host "  ClawGod Installer" -ForegroundColor White -NoNewline
 Write-Host " (Windows)" -ForegroundColor DarkGray
 Write-Host ""
 
-# ─── Uninstall ────────────────────────────────────────
+# --- Uninstall --------------------------------------------------------
 
 if ($Uninstall) {
     # Restore original claude
@@ -84,7 +84,7 @@ if ($Uninstall) {
     exit 0
 }
 
-# ─── Prerequisites ────────────────────────────────────
+# --- Prerequisites ----------------------------------------------------
 
 try { $null = Get-Command node -ErrorAction Stop }
 catch {
@@ -98,7 +98,7 @@ if ($nodeVer -lt 18) {
     exit 1
 }
 
-# ─── Ensure Bun (runtime that executes the patched cli.js) ────────────
+# --- Ensure Bun (runtime that executes the patched cli.js) ------------
 
 $BunBin = $null
 try { $BunBin = (Get-Command bun -ErrorAction Stop).Source } catch {}
@@ -118,9 +118,9 @@ if (-not $BunBin) {
     }
 }
 
-# Resolve bun.ps1 → bun.exe. When Bun is installed via `npm install -g bun`,
+# Resolve bun.ps1 -> bun.exe. When Bun is installed via `npm install -g bun`,
 # Get-Command returns a .ps1 wrapper script. A .cmd launcher cannot invoke .ps1
-# directly — Windows opens the file association dialog instead of executing it.
+# directly -- Windows opens the file association dialog instead of executing it.
 # Probe known install paths instead of parsing wrapper scripts.
 if ($BunBin -and $BunBin -match '\.ps1$') {
     $resolved = $null
@@ -144,7 +144,7 @@ if ($BunBin -and $BunBin -match '\.ps1$') {
         if (Test-Path $chocoBin) { $resolved = $chocoBin }
     }
     if ($resolved) {
-        Write-Dim "Resolved bun.ps1 → $resolved"
+        Write-Dim "Resolved bun.ps1 -> $resolved"
         $BunBin = $resolved
     } else {
         Write-Warn "Bun resolved to .ps1 wrapper ($BunBin). The launcher may not work."
@@ -153,11 +153,11 @@ if ($BunBin -and $BunBin -match '\.ps1$') {
 }
 Write-OK "Bun: $(& $BunBin --version)"
 
-# ─── Bun version pre-flight ───────────────────────────────────────────
+# --- Bun version pre-flight -------------------------------------------
 # Anthropic builds the native binary with Bun's canary channel; stable
 # bun.sh trails by one version. Bun < 1.3.14 panics on cli.original.cjs
 # with "Expected CommonJS module to have a function wrapper". Refuse
-# early — no npm download / no patch / no late sanity surprise where
+# early -- no npm download / no patch / no late sanity surprise where
 # PowerShell's NativeCommandError display buries the friendly message.
 # Bump $MinBunVersion when Anthropic moves the embedded Bun forward
 # again.
@@ -197,8 +197,8 @@ if (-not $BunVersionOk) {
     exit 1
 }
 
-# ─── ripgrep prerequisite (search/grep tool) ──────────────────────────
-# Hard prerequisite — without rg the Grep tool inside Claude Code fails.
+# --- ripgrep prerequisite (search/grep tool) --------------------------
+# Hard prerequisite -- without rg the Grep tool inside Claude Code fails.
 
 try {
     $rgPath = (Get-Command rg -ErrorAction Stop).Source
@@ -216,7 +216,7 @@ catch {
     exit 1
 }
 
-# ─── Handle -NoUpgrade (skip download, re-patch only) ────────────────
+# --- Handle -NoUpgrade (skip download, re-patch only) -----------------
 if ($NoUpgrade) {
     New-Item -ItemType Directory -Force -Path $ClawDir | Out-Null
     New-Item -ItemType Directory -Force -Path $BinDir  | Out-Null
@@ -234,9 +234,9 @@ if ($NoUpgrade) {
     Write-OK "Skipping download (-NoUpgrade)"
 } else {
 
-# ─── Locate native Bun binary (cli.js source) ──────────────────────────
+# --- Locate native Bun binary (cli.js source) -------------------------
 # Source: npm registry (@anthropic-ai/claude-code-win32-<arch>).
-# Local binary detection is intentionally skipped — see policy note below.
+# Local binary detection is intentionally skipped -- see policy note below.
 
 New-Item -ItemType Directory -Force -Path $ClawDir | Out-Null
 New-Item -ItemType Directory -Force -Path $BinDir  | Out-Null
@@ -261,12 +261,12 @@ $platformSuffix = "win32-$arch"
 # out `claude update`, so users never re-run the underlying installers,
 # and those directories freeze at whatever version was on disk the day
 # clawgod was first installed. `claude update` (which is now redirected
-# here) would re-detect the frozen binary forever — never reaching the
+# here) would re-detect the frozen binary forever -- never reaching the
 # registry. See INCIDENT_LOG 2026-04-29 entry. The fix is to skip local
 # detection entirely; the npm tarball is ~60-90 MB compressed, fetched
 # once per upgrade.
 
-# npm registry — pull the platform tarball directly via Node.
+# npm registry -- pull the platform tarball directly via Node.
 #    Avoids depending on `npm` and `tar` being on PATH (older Windows 10
 #    builds lack tar.exe; some PowerShell shims mangle `& npm`). Node is
 #    already a hard prerequisite for the patcher, so reuse it.
@@ -280,7 +280,7 @@ if (-not $NativeBin) {
     $noProxy = $env:NO_PROXY
     if ($env:HTTPS_PROXY -or $env:HTTP_PROXY) {
         if ($noProxy -match '(?i)npmjs\.org') {
-            Write-Dim "NO_PROXY includes npmjs.org — using direct fetch"
+            Write-Dim "NO_PROXY includes npmjs.org -- using direct fetch"
         } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
             $useNpmFetch = $true
         } else {
@@ -359,7 +359,7 @@ $extractorPath = Join-Path $ClawDir "extract-natives.mjs"
 {{CLAWGOD:extract-natives.mjs}}
 '@ | Set-Content $extractorPath -Encoding UTF8
 
-# ─── Extract cli.js + native modules from Bun binary ──────────
+# --- Extract cli.js + native modules from Bun binary ------------------
 
 # Single extractor pass: writes cli.original.js to $ClawDir and creates
 # vendor\<name>\<arch>-<os>\<name>.node for every napi module in one go.
@@ -381,9 +381,9 @@ if (-not (Test-Path $dstCli)) {
     exit 1
 }
 
-# Note: keep extractorPath around — repatch.mjs uses it on version drift
+# Note: keep extractorPath around -- repatch.mjs uses it on version drift
 
-# ─── Post-process cli.js for Bun runtime ──────────────────────
+# --- Post-process cli.js for Bun runtime -------------------------------
 
 Write-Dim "Rewriting bunfs paths and IIFE invocation ..."
 $postProc = Join-Path $ClawDir "post-process.mjs"
@@ -399,7 +399,7 @@ if (-not (Test-Path (Join-Path $ClawDir "cli.original.cjs"))) {
 # Stamp source version so wrapper can detect drift on next launch
 Set-Content -Path (Join-Path $ClawDir ".source-version") -Value $NativeBinLabel -Encoding ASCII
 
-# If we pulled the binary from npm into a tmpdir, clean up — extraction
+# If we pulled the binary from npm into a tmpdir, clean up -- extraction
 # is done; drift detection only consults %USERPROFILE%\.local\share\claude\versions\.
 if ($NativeBinTmpDir -and (Test-Path $NativeBinTmpDir)) {
     Remove-Item -Recurse -Force $NativeBinTmpDir -ErrorAction SilentlyContinue
@@ -409,18 +409,18 @@ Write-OK "cli.original.cjs ready ($NativeBinLabel)"
 
 }  # end -NoUpgrade skip
 
-# ─── Write re-patch helper (used by wrapper on version drift) ─────────
+# --- Write re-patch helper (used by wrapper on version drift) ---------
 
 @'
 {{CLAWGOD:repatch.mjs}}
 '@ | Set-Content (Join-Path $ClawDir "repatch.mjs") -Encoding UTF8
 Write-OK "Re-patch helper installed (repatch.mjs)"
 
-# ─── Write OpenAI-compatible proxy ────────────────────────────
+# --- Write OpenAI-compatible proxy ------------------------------------
 
 # NOTE: PowerShell here-string @'...'@ cannot contain a line starting with '@
 # The proxy source is identical to the install.sh version.
-# $PSScriptRoot is empty when run via iex (e.g. claude update → iex(irm $url)).
+# $PSScriptRoot is empty when run via iex (e.g. claude update -> iex(irm $url)).
 # Join-Path "" "file" throws a terminating error that -ErrorAction cannot catch.
 try { $ProxySource = Get-Content (Join-Path $PSScriptRoot "openai-proxy.cjs") -Raw -ErrorAction Stop } catch { $ProxySource = $null }
 if (-not $ProxySource) {
@@ -432,7 +432,7 @@ if (-not $ProxySource) {
 $ProxySource | Set-Content (Join-Path $ClawDir "openai-proxy.cjs") -Encoding UTF8
 Write-OK "OpenAI-compatible proxy created (openai-proxy.cjs)"
 
-# ─── Write wrapper (cli.cjs, runs under Bun) ──────────────────
+# --- Write wrapper (cli.cjs, runs under Bun) --------------------------
 
 @'
 {{CLAWGOD:cli.cjs}}
@@ -440,8 +440,8 @@ Write-OK "OpenAI-compatible proxy created (openai-proxy.cjs)"
 Set-Content (Join-Path $ClawDir ".clawgod-version") $ClawSelfVersion
 Write-OK "Wrapper created (cli.cjs)"
 
-# ─── Write universal patcher ──────────────────────────
-# (Same Node.js patcher as bash version — inline to avoid extra download)
+# --- Write universal patcher ------------------------------------------
+# (Same Node.js patcher as bash version -- inline to avoid extra download)
 
 $patcherCode = @'
 {{CLAWGOD:patch.mjs}}
@@ -450,7 +450,7 @@ $patcherCode = @'
 Set-Content (Join-Path $ClawDir "patch.mjs") $patcherCode -Encoding UTF8
 Write-OK "Patcher created (patch.mjs)"
 
-# ─── Apply patches ────────────────────────────────────
+# --- Apply patches ----------------------------------------------------
 
 Write-Dim "Applying patches ..."
 node (Join-Path $ClawDir "patch.mjs")
@@ -459,7 +459,7 @@ if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-# ─── Create default configs ───────────────────────────
+# --- Create default configs -------------------------------------------
 
 $featuresFile = Join-Path $ClawDir "features.json"
 if (-not (Test-Path $featuresFile)) {
@@ -470,7 +470,7 @@ if (-not (Test-Path $featuresFile)) {
     Write-OK "Default features.json created"
 }
 
-# ─── Lean mode: optimize ~/.claude/settings.json ─────
+# --- Lean mode: optimize ~/.claude/settings.json ----------------------
 $leanOffFlag = Join-Path $ClawDir ".lean-disabled"
 $leanMaxFlag = Join-Path $ClawDir ".lean-max"
 $claudeSettingsDir = Join-Path $env:USERPROFILE ".claude"
@@ -509,11 +509,11 @@ if (-not (Test-Path $leanOffFlag)) {
     Write-Host "  $([char]0x2022) Lean mode disabled (claude --lean-on to re-enable)" -ForegroundColor DarkGray
 }
 
-# ─── Sanity check: ensure user's Bun can actually load cli.original.cjs ──
+# --- Sanity check: ensure user's Bun can load cli.original.cjs --------
 # Anthropic builds the native binary with a bleeding-edge Bun build (e.g.
 # 1.3.14 while stable still ships 1.3.13). Older Bun crashes loading the
 # extracted cli.original.cjs with "Expected CommonJS module to have a
-# function wrapper". Detect this BEFORE we install the launcher — better
+# function wrapper". Detect this BEFORE we install the launcher -- better
 # to fail loudly than to leave the user with a launcher that panics on
 # first invocation.
 
@@ -524,7 +524,7 @@ $sanityCli = Join-Path $ClawDir "cli.cjs"
 # this script is piped through `iex`) that terminates BEFORE we even
 # read $sanityOut. Localize ErrorActionPreference + try/catch so the
 # panic message reliably lands in $sanityOut and our friendly Write-Err
-# block runs. Defense-in-depth — pre-flight already blocks Bun < $MinBunVersion;
+# block runs. Defense-in-depth -- pre-flight already blocks Bun < $MinBunVersion;
 # this remains for the day Anthropic bumps embedded Bun past our constant.
 $sanityOut = $null
 try {
@@ -544,7 +544,7 @@ if ($sanityOut -match "Expected CommonJS module to have a function wrapper") {
     Write-Err ""
     Write-Err "  Anthropic builds with Bun's canary channel (currently ~1.3.14), while"
     Write-Err "  bun.sh's main download is on stable (currently 1.3.13). The canary build"
-    Write-Err "  is NOT visible on bun.sh's download page — it lives on GitHub Releases"
+    Write-Err "  is NOT visible on bun.sh's download page -- it lives on GitHub Releases"
     Write-Err "  and is reachable only via 'bun upgrade --canary'."
     Write-Err ""
     Write-Err "  If your bun is from bun.sh:"
@@ -557,7 +557,7 @@ if ($sanityOut -match "Expected CommonJS module to have a function wrapper") {
     Write-Err "    irm https://bun.sh/install.ps1 | iex"
     Write-Err "    bun upgrade --canary"
     Write-Err ""
-    Write-Err "  Then re-run .\install.ps1 — this sanity check will pass."
+    Write-Err "  Then re-run .\install.ps1 -- this sanity check will pass."
     exit 1
 }
 if ($sanityExitCode -ne 0) {
@@ -568,7 +568,7 @@ if ($sanityExitCode -ne 0) {
 }
 Write-OK "Bun loads cli.original.cjs"
 
-# ─── Replace claude command ───────────────────────────
+# --- Replace claude command -------------------------------------------
 
 # Build launcher content using %USERPROFILE% env var where possible to avoid
 # encoding issues when the profile path contains non-ASCII characters (e.g.
@@ -583,7 +583,7 @@ if ($normalizedBunBin.Equals($normalizedUserProfile, [StringComparison]::Ordinal
     $bunRelative = $normalizedBunBin.Substring($normalizedUserProfile.Length).TrimStart('\', '/')
     $bunPathInCmd = "%USERPROFILE%\$bunRelative"
 } else {
-    # Bun outside USERPROFILE (e.g. system-wide install) — fall back to
+    # Bun outside USERPROFILE (e.g. system-wide install) -- fall back to
     # absolute path since %USERPROFILE%-relative expansion doesn't apply.
     $bunPathInCmd = $BunBin
 }
@@ -620,13 +620,13 @@ foreach ($loc in @(
         # Back up .exe if exists and not already backed up
         if ($loc -like "*.exe" -and -not (Test-Path $claudeOrigExe)) {
             Copy-Item $loc $claudeOrigExe -Force
-            Write-OK "Original claude.exe backed up → claude.orig.exe"
+            Write-OK "Original claude.exe backed up -> claude.orig.exe"
             $originalFound = $true
         }
         # Back up .cmd if exists and not already backed up
         if ($loc -like "*.cmd" -and -not (Test-Path $claudeOrigCmd)) {
             Copy-Item $loc $claudeOrigCmd -Force
-            Write-OK "Original claude.cmd backed up → claude.orig.cmd"
+            Write-OK "Original claude.cmd backed up -> claude.orig.cmd"
             $originalFound = $true
         }
         # If it's a versions directory, find the latest exe
@@ -634,7 +634,7 @@ foreach ($loc in @(
             $latestExe = Get-ChildItem $loc -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
             if ($latestExe -and -not (Test-Path $claudeOrigExe)) {
                 Copy-Item $latestExe.FullName $claudeOrigExe -Force
-                Write-OK "Original claude backed up → claude.orig.exe ($($latestExe.Name))"
+                Write-OK "Original claude backed up -> claude.orig.exe ($($latestExe.Name))"
                 $originalFound = $true
             }
         }
@@ -652,13 +652,13 @@ Get-ChildItem $BinDir -Filter "claude.*.exe" -ErrorAction SilentlyContinue |
 if (Test-Path $claudeExe) {
     if (-not (Test-Path $claudeOrigExe)) {
         Rename-Item $claudeExe $claudeOrigExe -Force
-        Write-OK "Renamed claude.exe → claude.orig.exe"
+        Write-OK "Renamed claude.exe -> claude.orig.exe"
     } else {
-        # Backup already exists — just remove the new claude.exe
+        # Backup already exists -- just remove the new claude.exe
         try {
             Remove-Item -Force $claudeExe
         } catch {
-            # File locked (running process) — rename aside with timestamp
+            # File locked (running process) -- rename aside with timestamp
             $ts = Get-Date -Format "yyyyMMddHHmmss"
             Rename-Item $claudeExe "claude.$ts.exe" -Force -ErrorAction SilentlyContinue
         }
@@ -676,9 +676,9 @@ if (Test-Path $claudeExe) {
 foreach ($cmd in @("claude", "clawgod")) {
     $launcherContent | Set-Content (Join-Path $BinDir "$cmd.cmd") -Encoding Default
 }
-Write-OK "Commands 'claude' + 'clawgod' → patched"
+Write-OK "Commands 'claude' + 'clawgod' -> patched"
 
-# ─── Ensure BinDir is in PATH ─────────────────────────
+# --- Ensure BinDir is in PATH -----------------------------------------
 
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($userPath -notlike "*$BinDir*") {
@@ -688,16 +688,16 @@ if ($userPath -notlike "*$BinDir*") {
     Write-Dim "(restart terminal for PATH to take effect)"
 }
 
-# ─── Done ─────────────────────────────────────────────
+# --- Done -------------------------------------------------------------
 
 Write-Host ""
 Write-Host "  ClawGod installed!" -ForegroundColor Green
 Write-Host ""
-Write-Dim "  claude            — Start patched Claude Code (green logo)"
-Write-Dim "  claude.orig       — Run original unpatched Claude Code"
+Write-Dim "  claude            -- Start patched Claude Code (green logo)"
+Write-Dim "  claude.orig       -- Run original unpatched Claude Code"
 Write-Host ""
 Write-Dim "  Updates: 'claude update' is patched to route through this installer."
-Write-Dim "  Just run it as usual — pulls latest Anthropic release + re-patches"
+Write-Dim "  Just run it as usual -- pulls latest Anthropic release + re-patches"
 Write-Dim "  in one step. Extra options:"
 Write-Dim "    claude update --version 2.1.180   (install a specific version)"
 Write-Dim "    claude update --no-upgrade        (re-patch without downloading)"
@@ -712,6 +712,6 @@ Write-Host ""
 Write-Dim "  If 'claude' panics with 'Expected CommonJS module to have a function wrapper',"
 Write-Dim "  your Bun lags Anthropic's embedded Bun. Upgrade with one of:"
 Write-Dim "    bun upgrade --canary           (if installed from bun.sh)"
-Write-Dim "    scoop update bun               (scoop — may lag stable)"
+Write-Dim "    scoop update bun               (scoop -- may lag stable)"
 Write-Dim "    irm https://bun.sh/install.ps1 | iex   (re-install latest)"
 Write-Host ""


### PR DESCRIPTION
## Summary

- generate `install.ps1` without a UTF-8 BOM so `irm ... | iex` starts directly at `#Requires`
- keep the artifact ASCII-only for Windows PowerShell 5.1 by escaping Unicode inside embedded JavaScript/JSON payloads
- exercise the installer through `Invoke-Expression` in Windows CI and assert the release artifact is BOM-free ASCII

## Root cause

`Invoke-RestMethod` decodes the response before passing it to `Invoke-Expression`. The UTF-8 BOM added in v1.9.2 therefore survived as a literal U+FEFF before `#Requires`, which made both `#Requires` and the following `param(...)` block parse incorrectly. The resulting `$Version` array produced the reported `latest False False False False False` registry URL.

## Verification

- `node build.js --check`
- generated `install.ps1` starts with `#Requires` and every byte is ASCII
- all 10 embedded JS/JSON payloads pass syntax parsing
- workflow YAML parses successfully
- `install.sh` remains byte-for-byte unchanged

Fixes #162