### PR TITLE
feat(patches): dangerous rm/rmdir asks skip-immune to bypassPermissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Green logo = patched. Orange logo = original.
 | **Computer Use** | Screen control without Max/Pro subscription (macOS) |
 | **Auto-mode** | Unlocks auto-mode for third-party API users (no firstParty gate) |
 | **Classifier tuning** | Tunable auto-mode classifier: timeout / model / retries (`CLAWGOD_CLASSIFIER_TIMEOUT_MS`, `CLAWGOD_CLASSIFIER_MODEL`, `CLAWGOD_CLASSIFIER_RETRIES`) |
+| **Dangerous rm bypass** | rm/rmdir "Dangerous operation" hard asks are skipped under `bypassPermissions` like other asks; auto mode still routes them through the classifier |
 | **Ultraplan** | Multi-agent planning via Claude Code Remote |
 | **Ultrareview** | Automated bug hunting via Claude Code Remote |
 
@@ -135,6 +136,7 @@ claude.orig         # Original unpatched version (auto-backed-up)
 | `voice-mode` | Voice Mode |
 | `auto-mode` | Auto-mode model selection on third-party APIs |
 | `classifier-tuning` | Auto-mode classifier overrides: `CLAWGOD_CLASSIFIER_TIMEOUT_MS` (min deadline; unset = 60-120s by context, v2.1.251+), `CLAWGOD_CLASSIFIER_MODEL`, `CLAWGOD_CLASSIFIER_RETRIES` (unset = 4) |
+| `dangerous-rm-bypass` | dangerous rm/rmdir confirmations are skipped under `bypassPermissions` like other asks; auto/default modes unchanged (v2.1.251+) |
 | `theme` | Green brand/logo color scheme |
 | `geo-neutralize` | Geo/proxy steganography neutralization in system prompt |
 | `cyber-risk` | Removes CYBER_RISK_INSTRUCTION from system prompt |

--- a/README_JP.md
+++ b/README_JP.md
@@ -51,6 +51,7 @@ irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 | ie
 | **Computer Use** | Max/Proサブスク不要で画面操作（macOS） |
 | **Auto-mode** | サードパーティ API ユーザー向け auto-mode のロック解除（firstParty 制限を撤去） |
 | **Classifier チューニング** | auto-mode 分類器の調整：タイムアウト / モデル / リトライ回数（`CLAWGOD_CLASSIFIER_TIMEOUT_MS`、`CLAWGOD_CLASSIFIER_MODEL`、`CLAWGOD_CLASSIFIER_RETRIES`） |
+| **Dangerous rm bypass** | `bypassPermissions` モードでは rm/rmdir などの危険操作の確認も他の操作と同様にスキップする；auto モードは引き続き分類器で判定 |
 | **Ultraplan** | Claude Code Remote 経由のマルチエージェント計画 |
 | **Ultrareview** | Claude Code Remote 経由の自動バグ検出 |
 
@@ -135,6 +136,7 @@ claude.orig         # オリジナル未修正版（自動バックアップ）
 | `voice-mode` | Voice Mode |
 | `auto-mode` | サードパーティ API での auto-mode モデル選択 |
 | `classifier-tuning` | auto-mode 分類器の上書き：`CLAWGOD_CLASSIFIER_TIMEOUT_MS`（deadline の下限；未設定=コンテキストにより 60-120s、v2.1.251+ 必要）、`CLAWGOD_CLASSIFIER_MODEL`、`CLAWGOD_CLASSIFIER_RETRIES`（未設定=4） |
+| `dangerous-rm-bypass` | `bypassPermissions` モードでは rm/rmdir などの危険操作の確認も他の操作と同様にスキップされる；auto/default モードの挙動は不変（v2.1.251+ 必要） |
 | `theme` | 緑色ブランド/ロゴ配色 |
 | `geo-neutralize` | system prompt の地域/プロキシステガノグラフィ中和 |
 | `cyber-risk` | system prompt から CYBER_RISK_INSTRUCTION を削除 |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -51,6 +51,7 @@ irm https://github.com/0Chencc/clawgod/releases/latest/download/install.ps1 | ie
 | **Computer Use** | 无需 Max/Pro 订阅即可使用屏幕控制（macOS） |
 | **Auto-mode** | 解锁第三方 API 用户的 auto-mode（移除 firstParty 限制） |
 | **Classifier 调优** | Auto-mode 分类器可调：超时 / 模型 / 重试次数（`CLAWGOD_CLASSIFIER_TIMEOUT_MS`、`CLAWGOD_CLASSIFIER_MODEL`、`CLAWGOD_CLASSIFIER_RETRIES`） |
+| **Dangerous rm bypass** | `bypassPermissions` 模式下 rm/rmdir 等危险操作也不再弹确认框，而是像其他操作一样直接执行；auto 模式仍由分类器判定 |
 | **Ultraplan** | 通过 Claude Code Remote 进行多智能体规划 |
 | **Ultrareview** | 通过 Claude Code Remote 自动化 Bug 查找 |
 
@@ -135,6 +136,7 @@ claude.orig         # 原版未修改版本（自动备份）
 | `voice-mode` | Voice Mode |
 | `auto-mode` | 第三方 API 的 auto-mode 模型选择 |
 | `classifier-tuning` | Auto-mode 分类器覆盖：`CLAWGOD_CLASSIFIER_TIMEOUT_MS`（deadline 下限；未设置=按上下文 60-120s，需 v2.1.251+）、`CLAWGOD_CLASSIFIER_MODEL`、`CLAWGOD_CLASSIFIER_RETRIES`（未设置=4） |
+| `dangerous-rm-bypass` | `bypassPermissions` 模式下 rm/rmdir 等危险操作不再弹确认框，直接执行；auto/default 模式行为不变（需 v2.1.251+） |
 | `theme` | 绿色品牌/Logo 配色 |
 | `geo-neutralize` | 中和 system prompt 中的地区/代理隐写 |
 | `cyber-risk` | 移除 system prompt 中的 CYBER_RISK_INSTRUCTION |

--- a/install.ps1
+++ b/install.ps1
@@ -1344,6 +1344,9 @@ const CLAWGOD_FEATURES_META = {
   "classifier-retries": [
     "classifier-tuning"
   ],
+  "dangerous-rm-bypass": [
+    "dangerous-rm-bypass"
+  ],
   "theme-logo-rgb": [
     "theme"
   ],
@@ -1791,6 +1794,8 @@ const FEATURES = {
                       patchIds: ['auto-mode-helper-gate', 'auto-mode-inline-gate'] },
   'classifier-tuning': { desc: 'Auto-mode classifier overrides (timeout/model/retries env vars)',
                       patchIds: ['classifier-timeout', 'classifier-model', 'classifier-retries'] },
+  'dangerous-rm-bypass': { desc: 'skip dangerous rm/rmdir confirmation under bypassPermissions mode',
+                      patchIds: ['dangerous-rm-bypass'] },
   'theme':          { desc: 'Green brand/logo color scheme',
                       patchIds: [
                         'theme-logo-rgb', 'theme-logo-ansi',
@@ -2036,6 +2041,35 @@ const patches = [
       `function ${fn}(){let _cr=process.env.CLAWGOD_CLASSIFIER_RETRIES?.trim();if(${gate('classifier-retries')}&&_cr!==undefined&&_cr!==""&&Number.isInteger(+_cr)&&+_cr>=0)return{value:+_cr,src:"default"};` + m.slice(m.indexOf('{') + 1),
     unique: true,
     optional: true,  // v2.1.220+; \u2264v2.1.143 uses a plain constant
+  },
+  {
+    // Bash rm/rmdir static-safety "hard ask" (Dangerous rm operation on
+    // statically-unresolvable target, critical system directory, cd+relative
+    // glob) carries circuitBreaker:"dangerousRemoval". The breaker table
+    // marks it {bypassImmune:!0,classifierRouted:!0}: the main permission
+    // flow (cS(decisionReason, EUe)) then re-raises the ask even under
+    // bypassPermissions. Patch flips only bypassImmune so:
+    //   bypass mode  -> ask is skipped like every other ask
+    //   auto mode    -> unchanged (classifier already routes it via
+    //                   classifierRouted, incl. the simple-command path)
+    //   default mode -> unchanged
+    // Compound-command aggregation (cd x && rm y/*) hard-returns on
+    // classifierApprovable===!1 before EUe is consulted, but its decisions
+    // also come from the same table, so bypass is covered there too.
+    // Table shape (v2.1.251+): var Lur={dangerousRemoval:{...},...}
+    //   dangerousRemoval:{bypassImmune:!0,classifierRouted:!0}
+    // bypassImmune becomes a getter so the table entry is re-read on every
+    // EUe() call \u2014 mutating globalThis.__clawgodPatches at runtime flips
+    // the behavior immediately, no reload needed.
+    // v2.1.220 predates the table (direct string compare), so optional.
+    id: 'dangerous-rm-bypass',
+    toggleable: true,
+    name: 'dangerousRemoval ask skippable in bypassPermissions',
+    pattern: /dangerousRemoval:\{bypassImmune:!0(,classifierRouted:!0\})/g,
+    replacer: (m, tail) =>
+      'dangerousRemoval:{get bypassImmune(){return !(' + gate('dangerous-rm-bypass') + ')}' + tail,
+    unique: true,
+    optional: true,  // breaker table introduced in v2.1.251
   },
   {
     // v2.1.158+: provider gate refactored into helper function:

--- a/install.sh
+++ b/install.sh
@@ -1207,6 +1207,9 @@ const CLAWGOD_FEATURES_META = {
   "classifier-retries": [
     "classifier-tuning"
   ],
+  "dangerous-rm-bypass": [
+    "dangerous-rm-bypass"
+  ],
   "theme-logo-rgb": [
     "theme"
   ],
@@ -1654,6 +1657,8 @@ const FEATURES = {
                       patchIds: ['auto-mode-helper-gate', 'auto-mode-inline-gate'] },
   'classifier-tuning': { desc: 'Auto-mode classifier overrides (timeout/model/retries env vars)',
                       patchIds: ['classifier-timeout', 'classifier-model', 'classifier-retries'] },
+  'dangerous-rm-bypass': { desc: 'skip dangerous rm/rmdir confirmation under bypassPermissions mode',
+                      patchIds: ['dangerous-rm-bypass'] },
   'theme':          { desc: 'Green brand/logo color scheme',
                       patchIds: [
                         'theme-logo-rgb', 'theme-logo-ansi',
@@ -1899,6 +1904,35 @@ const patches = [
       `function ${fn}(){let _cr=process.env.CLAWGOD_CLASSIFIER_RETRIES?.trim();if(${gate('classifier-retries')}&&_cr!==undefined&&_cr!==""&&Number.isInteger(+_cr)&&+_cr>=0)return{value:+_cr,src:"default"};` + m.slice(m.indexOf('{') + 1),
     unique: true,
     optional: true,  // v2.1.220+; ≤v2.1.143 uses a plain constant
+  },
+  {
+    // Bash rm/rmdir static-safety "hard ask" (Dangerous rm operation on
+    // statically-unresolvable target, critical system directory, cd+relative
+    // glob) carries circuitBreaker:"dangerousRemoval". The breaker table
+    // marks it {bypassImmune:!0,classifierRouted:!0}: the main permission
+    // flow (cS(decisionReason, EUe)) then re-raises the ask even under
+    // bypassPermissions. Patch flips only bypassImmune so:
+    //   bypass mode  -> ask is skipped like every other ask
+    //   auto mode    -> unchanged (classifier already routes it via
+    //                   classifierRouted, incl. the simple-command path)
+    //   default mode -> unchanged
+    // Compound-command aggregation (cd x && rm y/*) hard-returns on
+    // classifierApprovable===!1 before EUe is consulted, but its decisions
+    // also come from the same table, so bypass is covered there too.
+    // Table shape (v2.1.251+): var Lur={dangerousRemoval:{...},...}
+    //   dangerousRemoval:{bypassImmune:!0,classifierRouted:!0}
+    // bypassImmune becomes a getter so the table entry is re-read on every
+    // EUe() call — mutating globalThis.__clawgodPatches at runtime flips
+    // the behavior immediately, no reload needed.
+    // v2.1.220 predates the table (direct string compare), so optional.
+    id: 'dangerous-rm-bypass',
+    toggleable: true,
+    name: 'dangerousRemoval ask skippable in bypassPermissions',
+    pattern: /dangerousRemoval:\{bypassImmune:!0(,classifierRouted:!0\})/g,
+    replacer: (m, tail) =>
+      'dangerousRemoval:{get bypassImmune(){return !(' + gate('dangerous-rm-bypass') + ')}' + tail,
+    unique: true,
+    optional: true,  // breaker table introduced in v2.1.251
   },
   {
     // v2.1.158+: provider gate refactored into helper function:

--- a/src/shared/patch.mjs
+++ b/src/shared/patch.mjs
@@ -49,6 +49,8 @@ const FEATURES = {
                       patchIds: ['auto-mode-helper-gate', 'auto-mode-inline-gate'] },
   'classifier-tuning': { desc: 'Auto-mode classifier overrides (timeout/model/retries env vars)',
                       patchIds: ['classifier-timeout', 'classifier-model', 'classifier-retries'] },
+  'dangerous-rm-bypass': { desc: 'skip dangerous rm/rmdir confirmation under bypassPermissions mode',
+                      patchIds: ['dangerous-rm-bypass'] },
   'theme':          { desc: 'Green brand/logo color scheme',
                       patchIds: [
                         'theme-logo-rgb', 'theme-logo-ansi',
@@ -294,6 +296,35 @@ const patches = [
       `function ${fn}(){let _cr=process.env.CLAWGOD_CLASSIFIER_RETRIES?.trim();if(${gate('classifier-retries')}&&_cr!==undefined&&_cr!==""&&Number.isInteger(+_cr)&&+_cr>=0)return{value:+_cr,src:"default"};` + m.slice(m.indexOf('{') + 1),
     unique: true,
     optional: true,  // v2.1.220+; ≤v2.1.143 uses a plain constant
+  },
+  {
+    // Bash rm/rmdir static-safety "hard ask" (Dangerous rm operation on
+    // statically-unresolvable target, critical system directory, cd+relative
+    // glob) carries circuitBreaker:"dangerousRemoval". The breaker table
+    // marks it {bypassImmune:!0,classifierRouted:!0}: the main permission
+    // flow (cS(decisionReason, EUe)) then re-raises the ask even under
+    // bypassPermissions. Patch flips only bypassImmune so:
+    //   bypass mode  -> ask is skipped like every other ask
+    //   auto mode    -> unchanged (classifier already routes it via
+    //                   classifierRouted, incl. the simple-command path)
+    //   default mode -> unchanged
+    // Compound-command aggregation (cd x && rm y/*) hard-returns on
+    // classifierApprovable===!1 before EUe is consulted, but its decisions
+    // also come from the same table, so bypass is covered there too.
+    // Table shape (v2.1.251+): var Lur={dangerousRemoval:{...},...}
+    //   dangerousRemoval:{bypassImmune:!0,classifierRouted:!0}
+    // bypassImmune becomes a getter so the table entry is re-read on every
+    // EUe() call — mutating globalThis.__clawgodPatches at runtime flips
+    // the behavior immediately, no reload needed.
+    // v2.1.220 predates the table (direct string compare), so optional.
+    id: 'dangerous-rm-bypass',
+    toggleable: true,
+    name: 'dangerousRemoval ask skippable in bypassPermissions',
+    pattern: /dangerousRemoval:\{bypassImmune:!0(,classifierRouted:!0\})/g,
+    replacer: (m, tail) =>
+      'dangerousRemoval:{get bypassImmune(){return !(' + gate('dangerous-rm-bypass') + ')}' + tail,
+    unique: true,
+    optional: true,  // breaker table introduced in v2.1.251
   },
   {
     // v2.1.158+: provider gate refactored into helper function:


### PR DESCRIPTION
## Problem

Under `bypassPermissions`, Claude Code auto-skips every confirmation and executes directly. But dangerous `rm`/`rmdir` operations (statically-unresolvable target, critical system directory, `cd` + relative glob) carry `circuitBreaker:"dangerousRemoval"`, and its breaker-table entry `{bypassImmune:!0, classifierRouted:!0}` forces a manual confirmation even in bypass mode. So the one mode that should never pause still asks, breaking the flow.

## Reproduction

In `bypassPermissions` mode, tell Claude to run:

```bash
cd /tmp/drmtest && rm sub/*
```

Without this patch the command is blocked with:

```
Error: This Bash command contains multiple operations. The following parts require approval: cd /tmp/drmtest, rm sub/*
```


## Change

Turn `dangerousRemoval.bypassImmune` from a boolean into a runtime getter so it is no longer immune to bypass.

Behavior per mode:

| Mode | Before | After |
| --- | --- | --- |
| `bypassPermissions` | still asks | executes directly |
| `auto` | routed through classifier | unchanged |
| `default` | asks | unchanged |

Implementation notes:
- The getter re-reads `globalThis.__clawgodPatches` on every consultation, so toggling the gate at runtime takes effect immediately without a reload.
- Compound-command aggregation (`cd x && rm y/*`) shares the same breaker table, so bypass is covered there too.
- Feature id `dangerous-rm-bypass`; off restores upstream behavior exactly.
- Anchor exists in v2.1.251+ (breaker table); older bundles skip cleanly.

## Verification

Verified end-to-end on 2.1.260:
- `default` mode: command blocked, approval required (matches upstream)
- `bypassPermissions`: command executes directly
- `CLAWGOD_FEATURE_DANGEROUS_RM_BYPASS=false`: ask restored in bypass mode
